### PR TITLE
feat(agents): Linear/Notion-style org chart and detail-page slice

### DIFF
--- a/apps/ui/src/app/dashboard/agents/page.tsx
+++ b/apps/ui/src/app/dashboard/agents/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { Suspense, useMemo, useState } from "react";
-import { AgentRow, groupAgentsByTeam, getFleetCounts, buildAgentTree } from "@/components/agents/agent-card";
+import { Suspense, useEffect, useMemo, useState } from "react";
+import { AgentRow, groupAgentsByTeam, getFleetCounts } from "@/components/agents/agent-card";
+import { AgentOrgChart } from "@/components/agents/agent-org-chart";
 import { AgentForm } from "@/components/agents/agent-form";
 import { AgentCreateWizard } from "@/components/agents/agent-create-wizard";
 import { useAgents } from "@/hooks/use-agents";
@@ -16,19 +17,36 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Plus, Bot, Search, X, List, GitBranch } from "lucide-react";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { Plus, Bot, Search, X, LayoutList, Network } from "lucide-react";
 import { FirstVisitHint } from "@/components/onboarding/first-visit-hint";
 import type { Agent, AgentMeta } from "@/lib/agents/types";
 import { cn } from "@/lib/utils";
 import { ConfirmDialog } from "@/components/shared/confirm-dialog";
+
+type AgentsViewMode = "fleet" | "chart";
+const AGENTS_VIEW_KEY = "agents-view-mode";
 
 function AgentsContent() {
   const agents = useAgents();
   const [searchQuery, setSearchQuery] = useState("");
   const [statusFilter, setStatusFilter] = useState<string>("all");
   const [teamFilter, setTeamFilter] = useState<string>("all");
-  const [viewMode, setViewMode] = useState<"fleet" | "hierarchy">("fleet");
+  const [viewMode, setViewMode] = useState<AgentsViewMode>("fleet");
   const [pendingDelete, setPendingDelete] = useState<Agent | null>(null);
+
+  useEffect(() => {
+    const saved = localStorage.getItem(AGENTS_VIEW_KEY) as AgentsViewMode | null;
+    if (saved === "fleet" || saved === "chart") {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- hydration-safe restore
+      setViewMode(saved);
+    }
+  }, []);
+
+  function changeViewMode(mode: AgentsViewMode) {
+    setViewMode(mode);
+    localStorage.setItem(AGENTS_VIEW_KEY, mode);
+  }
 
   // Derive available teams from agent data
   const teams = useMemo(() => {
@@ -83,11 +101,6 @@ function AgentsContent() {
       agents.agents.length >= 4 &&
       agents.agents.some((a) => a.reports_to_id != null),
     [agents.agents],
-  );
-
-  const hierarchyTree = useMemo(
-    () => (viewMode === "hierarchy" ? buildAgentTree(filteredAgents) : []),
-    [viewMode, filteredAgents],
   );
 
   const hasActiveFilters =
@@ -192,34 +205,28 @@ function AgentsContent() {
             <div className="flex-1" />
 
             {hasHierarchy && (
-              <div className="flex items-center gap-0.5 rounded border border-border/40 p-0.5">
-                <button
-                  type="button"
-                  onClick={() => setViewMode("fleet")}
-                  className={cn(
-                    "rounded p-1 transition-colors",
-                    viewMode === "fleet"
-                      ? "bg-accent text-foreground"
-                      : "text-muted-foreground hover:text-foreground",
-                  )}
+              <ToggleGroup
+                type="single"
+                value={viewMode}
+                onValueChange={(v) => v && changeViewMode(v as AgentsViewMode)}
+                variant="outline"
+                size="sm"
+              >
+                <ToggleGroupItem
+                  value="fleet"
                   title="Fleet view"
+                  className="h-8 w-8 p-0"
                 >
-                  <List className="h-3 w-3" />
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setViewMode("hierarchy")}
-                  className={cn(
-                    "rounded p-1 transition-colors",
-                    viewMode === "hierarchy"
-                      ? "bg-accent text-foreground"
-                      : "text-muted-foreground hover:text-foreground",
-                  )}
-                  title="Hierarchy view"
+                  <LayoutList className="h-3.5 w-3.5" />
+                </ToggleGroupItem>
+                <ToggleGroupItem
+                  value="chart"
+                  title="Org chart view"
+                  className="h-8 w-8 p-0"
                 >
-                  <GitBranch className="h-3 w-3" />
-                </button>
-              </div>
+                  <Network className="h-3.5 w-3.5" />
+                </ToggleGroupItem>
+              </ToggleGroup>
             )}
 
             <span className="text-[11px] text-muted-foreground tabular-nums">
@@ -297,22 +304,16 @@ function AgentsContent() {
               </div>
             )}
 
-            {viewMode === "hierarchy" ? (
-              <div className="space-y-0.5">
-                {hierarchyTree.map((node) => (
-                  <AgentRow
-                    key={node.agent.id}
-                    agent={node.agent}
-                    depth={node.depth}
-                    onEdit={agents.form.openEditForm}
-                    onTogglePause={agents.actions.togglePause}
-                    onDelete={(id) => {
-                      const target = agents.agents.find((a) => a.id === id);
-                      if (target) setPendingDelete(target);
-                    }}
-                  />
-                ))}
-              </div>
+            {viewMode === "chart" ? (
+              <AgentOrgChart
+                agents={filteredAgents}
+                onEdit={agents.form.openEditForm}
+                onTogglePause={agents.actions.togglePause}
+                onDelete={(id) => {
+                  const target = agents.agents.find((a) => a.id === id);
+                  if (target) setPendingDelete(target);
+                }}
+              />
             ) : (
               <div className="space-y-4">
                 {teamGroups.map((group) => (

--- a/apps/ui/src/components/agents/agent-card.tsx
+++ b/apps/ui/src/components/agents/agent-card.tsx
@@ -17,7 +17,7 @@ const STATUS_PRIORITY: Record<string, number> = {
   hibernating: 4,
 };
 
-const AGENT_STATUS: Record<
+export const AGENT_STATUS: Record<
   string,
   { color: string; label: string; pulse?: boolean }
 > = {
@@ -81,30 +81,6 @@ export function getFleetCounts(agents: Agent[]) {
     if (c > 0) counts.push({ status, count: c, color: cfg.color, label: cfg.label.toLowerCase() });
   }
   return counts;
-}
-
-export interface AgentTreeNode {
-  agent: Agent;
-  depth: number;
-}
-
-export function buildAgentTree(agents: Agent[]): AgentTreeNode[] {
-  const childrenMap = new Map<string | null, Agent[]>();
-  for (const a of agents) {
-    const key = a.reports_to_id ?? null;
-    if (!childrenMap.has(key)) childrenMap.set(key, []);
-    childrenMap.get(key)!.push(a);
-  }
-  const nodes: AgentTreeNode[] = [];
-  function walk(parentId: string | null, depth: number) {
-    const children = childrenMap.get(parentId) ?? [];
-    for (const child of sortAgentsByStatus(children)) {
-      nodes.push({ agent: child, depth: Math.min(depth, 3) });
-      walk(child.id, depth + 1);
-    }
-  }
-  walk(null, 0);
-  return nodes;
 }
 
 interface AgentRowProps {
@@ -195,14 +171,14 @@ export function AgentRow({
       {/* Hover actions */}
       <div className="absolute right-3 top-1/2 -translate-y-1/2 z-10 flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
         {onEdit && (
-          <IconButton
+          <AgentIconButton
             label="Edit"
             onClick={() => onEdit(agent)}
             icon={<Pencil className="h-3 w-3" />}
           />
         )}
         {onTogglePause && (
-          <IconButton
+          <AgentIconButton
             label={agent.status === "paused" ? "Resume" : "Pause"}
             onClick={() => onTogglePause(agent.id, agent.status)}
             icon={
@@ -215,7 +191,7 @@ export function AgentRow({
           />
         )}
         {onDelete && (
-          <IconButton
+          <AgentIconButton
             label="Delete"
             onClick={() => onDelete(agent.id)}
             icon={<Trash2 className="h-3 w-3" />}
@@ -227,7 +203,7 @@ export function AgentRow({
   );
 }
 
-function AgentUsagePill({ agentId }: { agentId: string }) {
+export function AgentUsagePill({ agentId }: { agentId: string }) {
   const { budget } = useAgentBudget(agentId);
   if (!budget || (budget.current_period_spend_usd === 0 && budget.current_period_tokens === 0)) {
     return null;
@@ -259,7 +235,7 @@ function AgentUsagePill({ agentId }: { agentId: string }) {
   );
 }
 
-function IconButton({
+export function AgentIconButton({
   label,
   onClick,
   icon,

--- a/apps/ui/src/components/agents/agent-detail-tabs.tsx
+++ b/apps/ui/src/components/agents/agent-detail-tabs.tsx
@@ -24,11 +24,6 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { StatusDot } from "@/components/ui/status-dot";
 import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
-import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -49,6 +44,7 @@ import { RoutinesSection } from "@/components/routines/routines-section";
 import { OpenDesktopModal } from "@/components/gateways/open-desktop-modal";
 import { getGatewayDesktopUrlAction } from "@/app/dashboard/settings/gateways/actions";
 import { AgentModelSection } from "@/components/agents/agent-model-section";
+import { AgentOrgSlice } from "@/components/agents/agent-org-slice";
 import { AgentUsageRail } from "./agent-usage-rail";
 import { AgentUsageTab } from "./agent-usage-tab";
 import { AgentKnowledgeSection } from "./agent-knowledge-section";
@@ -288,16 +284,6 @@ function AgentRailContent({
     ? formatDistanceToNow(new Date(agent.last_seen_at), { addSuffix: true })
     : "Never";
 
-  const manager = useMemo(
-    () => allAgents.find((a) => a.id === agent.reports_to_id) ?? null,
-    [allAgents, agent.reports_to_id],
-  );
-  const directReports = useMemo(
-    () => allAgents.filter((a) => a.reports_to_id === agent.id),
-    [allAgents, agent.id],
-  );
-
-  const [managerPickerOpen, setManagerPickerOpen] = useState(false);
   const [savingManager, setSavingManager] = useState(false);
   const [togglingPause, setTogglingPause] = useState(false);
 
@@ -331,15 +317,9 @@ function AgentRailContent({
         );
       } finally {
         setSavingManager(false);
-        setManagerPickerOpen(false);
       }
     },
     [agent.id, onAgentUpdated],
-  );
-
-  const managerCandidates = useMemo(
-    () => allAgents.filter((a) => a.id !== agent.id),
-    [allAgents, agent.id],
   );
 
   return (
@@ -358,80 +338,22 @@ function AgentRailContent({
 
       <AgentUsageRail agentId={agent.id} />
 
+      {allAgents.length > 1 && (
+        <DetailSidebarSection title="Org">
+          <AgentOrgSlice
+            agent={agent}
+            allAgents={allAgents}
+            onChangeManager={handleManagerChange}
+            disabled={savingManager}
+          />
+        </DetailSidebarSection>
+      )}
+
       <DetailSidebarSection title="Properties">
         <DetailSidebarPropertyGrid>
           <DetailSidebarProperty label="Slug">
             <span className="font-mono text-foreground/80">@{agent.slug}</span>
           </DetailSidebarProperty>
-          {allAgents.length > 1 && (
-            <DetailSidebarProperty label="Manager">
-              <Popover
-                open={managerPickerOpen}
-                onOpenChange={setManagerPickerOpen}
-              >
-                <PopoverTrigger asChild>
-                  <button
-                    type="button"
-                    disabled={savingManager}
-                    className="text-left text-foreground/80 hover:text-foreground transition-colors"
-                  >
-                    {manager ? (
-                      <span>
-                        {(manager.meta as AgentMeta)?.emoji
-                          ? `${(manager.meta as AgentMeta).emoji} `
-                          : ""}
-                        {manager.name}
-                      </span>
-                    ) : (
-                      <span className="text-muted-foreground/60">
-                        Operator (you)
-                      </span>
-                    )}
-                  </button>
-                </PopoverTrigger>
-                <PopoverContent className="w-52 p-1" align="start">
-                  <button
-                    type="button"
-                    onClick={() => handleManagerChange(null)}
-                    className={cn(
-                      "flex w-full items-center gap-2 rounded px-2 py-1.5 text-[12px] hover:bg-accent text-left",
-                      !agent.reports_to_id && "bg-accent/60",
-                    )}
-                  >
-                    <span className="text-muted-foreground/60">
-                      Operator (you)
-                    </span>
-                  </button>
-                  {managerCandidates.map((a) => (
-                    <button
-                      key={a.id}
-                      type="button"
-                      onClick={() => handleManagerChange(a.id)}
-                      className={cn(
-                        "flex w-full items-center gap-2 rounded px-2 py-1.5 text-[12px] hover:bg-accent text-left",
-                        agent.reports_to_id === a.id && "bg-accent/60",
-                      )}
-                    >
-                      {(a.meta as AgentMeta)?.emoji && (
-                        <span className="text-[13px]">
-                          {(a.meta as AgentMeta).emoji}
-                        </span>
-                      )}
-                      <span className="truncate">{a.name}</span>
-                    </button>
-                  ))}
-                </PopoverContent>
-              </Popover>
-            </DetailSidebarProperty>
-          )}
-          {directReports.length > 0 && (
-            <DetailSidebarProperty label="Reports">
-              <span className="text-foreground/80">
-                {directReports.length} direct{" "}
-                {directReports.length === 1 ? "report" : "reports"}
-              </span>
-            </DetailSidebarProperty>
-          )}
           {agent.domains.length > 0 && (
             <DetailSidebarProperty label="Domains">
               <span className="flex flex-wrap gap-1">

--- a/apps/ui/src/components/agents/agent-node.tsx
+++ b/apps/ui/src/components/agents/agent-node.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import Link from "next/link";
+import { Bot, Pencil, Pause, Play, Trash2 } from "lucide-react";
+import type { Agent, AgentMeta } from "@/lib/agents/types";
+import { cn } from "@/lib/utils";
+import {
+  AGENT_STATUS,
+  AgentIconButton,
+  AgentUsagePill,
+} from "@/components/agents/agent-card";
+
+interface AgentNodeProps {
+  agent: Agent;
+  variant?: "default" | "pill";
+  asSelf?: boolean;
+  className?: string;
+  style?: React.CSSProperties;
+  onEdit?: (agent: Agent) => void;
+  onTogglePause?: (id: string, status: string) => void;
+  onDelete?: (id: string) => void;
+}
+
+/**
+ * Boxed agent card used by the org chart canvas (variant="default")
+ * and the detail-page neighborhood slice (variant="pill"). Density and
+ * trim match the existing AgentRow so swapping views feels continuous.
+ *
+ * `asSelf` renders without a link — used for the focal agent on the
+ * detail page where navigation would be a no-op.
+ */
+export function AgentNode({
+  agent,
+  variant = "default",
+  asSelf = false,
+  className,
+  style,
+  onEdit,
+  onTogglePause,
+  onDelete,
+}: AgentNodeProps) {
+  const status = AGENT_STATUS[agent.status] ?? AGENT_STATUS.error;
+  const meta = (agent.meta ?? {}) as AgentMeta;
+  const emoji = meta.emoji;
+  const hasActions = Boolean(onEdit || onTogglePause || onDelete);
+
+  const isPill = variant === "pill";
+
+  return (
+    <div
+      style={style}
+      className={cn(
+        "group relative flex items-center gap-2 rounded-md border border-border/60 bg-background transition-colors hover:bg-muted/30",
+        isPill ? "h-8 px-2 text-[12px]" : "h-[52px] px-2.5",
+        asSelf && "ring-1 ring-foreground/20 bg-accent/40 hover:bg-accent/40",
+        className,
+      )}
+    >
+      {!asSelf && (
+        <Link
+          href={`/dashboard/agents/${agent.id}`}
+          className="absolute inset-0 rounded-md"
+          aria-label={agent.name}
+        />
+      )}
+
+      {/* Avatar */}
+      <div
+        className={cn(
+          "flex shrink-0 items-center justify-center rounded bg-muted/50",
+          isPill ? "h-5 w-5 text-[12px]" : "h-7 w-7 text-[14px]",
+        )}
+      >
+        {agent.avatar_url ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={agent.avatar_url}
+            alt=""
+            className={cn(
+              "rounded object-cover",
+              isPill ? "h-5 w-5" : "h-7 w-7",
+            )}
+          />
+        ) : emoji ? (
+          <span>{emoji}</span>
+        ) : (
+          <Bot
+            className={cn(
+              "text-muted-foreground",
+              isPill ? "h-3 w-3" : "h-3.5 w-3.5",
+            )}
+          />
+        )}
+      </div>
+
+      {/* Status dot */}
+      <span
+        className={cn(
+          "shrink-0 rounded-full",
+          isPill ? "h-1 w-1" : "h-1.5 w-1.5",
+          status.pulse && "animate-pulse",
+        )}
+        style={{ backgroundColor: status.color }}
+        title={status.label}
+      />
+
+      {/* Name */}
+      <span
+        className={cn(
+          "min-w-0 flex-1 truncate font-medium text-foreground",
+          isPill ? "text-[12px]" : "text-[13px]",
+        )}
+      >
+        {agent.name}
+      </span>
+
+      {/* Slug + usage — only on the default size */}
+      {!isPill && (
+        <>
+          <span className="shrink-0 font-mono text-[11px] text-muted-foreground/60">
+            @{agent.slug}
+          </span>
+          <AgentUsagePill agentId={agent.id} />
+        </>
+      )}
+
+      {/* Hover actions */}
+      {hasActions && !isPill && (
+        <div className="absolute right-1.5 top-1/2 z-10 flex -translate-y-1/2 items-center gap-0.5 bg-background/90 opacity-0 transition-opacity group-hover:opacity-100">
+          {onEdit && (
+            <AgentIconButton
+              label="Edit"
+              onClick={() => onEdit(agent)}
+              icon={<Pencil className="h-3 w-3" />}
+            />
+          )}
+          {onTogglePause && (
+            <AgentIconButton
+              label={agent.status === "paused" ? "Resume" : "Pause"}
+              onClick={() => onTogglePause(agent.id, agent.status)}
+              icon={
+                agent.status === "paused" ? (
+                  <Play className="h-3 w-3" />
+                ) : (
+                  <Pause className="h-3 w-3" />
+                )
+              }
+            />
+          )}
+          {onDelete && (
+            <AgentIconButton
+              label="Delete"
+              onClick={() => onDelete(agent.id)}
+              icon={<Trash2 className="h-3 w-3" />}
+              destructive
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/ui/src/components/agents/agent-org-chart.tsx
+++ b/apps/ui/src/components/agents/agent-org-chart.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import type { Agent } from "@/lib/agents/types";
+import { sortAgentsByStatus } from "@/components/agents/agent-card";
+import { AgentNode } from "@/components/agents/agent-node";
+import { layoutOrgTree } from "@/lib/agents/org-layout";
+import { cn } from "@/lib/utils";
+
+interface AgentOrgChartProps {
+  agents: Agent[];
+  onEdit?: (agent: Agent) => void;
+  onTogglePause?: (id: string, status: string) => void;
+  onDelete?: (id: string) => void;
+}
+
+const NODE_W = 200;
+const NODE_H = 52;
+const GAP_X = 20;
+const GAP_Y = 36;
+
+export function AgentOrgChart({
+  agents,
+  onEdit,
+  onTogglePause,
+  onDelete,
+}: AgentOrgChartProps) {
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+
+  const sortedAgents = useMemo(() => sortAgentsByStatus(agents), [agents]);
+
+  const layout = useMemo(
+    () =>
+      layoutOrgTree(sortedAgents, {
+        nodeW: NODE_W,
+        nodeH: NODE_H,
+        gapX: GAP_X,
+        gapY: GAP_Y,
+        collapsed,
+      }),
+    [sortedAgents, collapsed],
+  );
+
+  const positions = useMemo(() => {
+    const map = new Map<string, { x: number; y: number; w: number; h: number }>();
+    for (const n of layout.nodes) {
+      map.set(n.agent.id, { x: n.x, y: n.y, w: n.w, h: n.h });
+    }
+    return map;
+  }, [layout.nodes]);
+
+  function toggleCollapsed(id: string) {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  return (
+    <div className="overflow-auto">
+      <div
+        className="relative"
+        style={{
+          width: Math.max(layout.width, 320),
+          height: Math.max(layout.height, NODE_H),
+        }}
+      >
+        {/* Connector elbows — quiet 1px lines, Notion-style */}
+        <svg
+          className="pointer-events-none absolute inset-0"
+          width={layout.width}
+          height={layout.height}
+          aria-hidden
+        >
+          {layout.edges.map((edge) => {
+            const from = positions.get(edge.fromId);
+            const to = positions.get(edge.toId);
+            if (!from || !to) return null;
+            const x1 = from.x + from.w / 2;
+            const y1 = from.y + from.h;
+            const x2 = to.x + to.w / 2;
+            const y2 = to.y;
+            const midY = y1 + (y2 - y1) / 2;
+            const path = `M ${x1} ${y1} V ${midY} H ${x2} V ${y2}`;
+            return (
+              <path
+                key={`${edge.fromId}-${edge.toId}`}
+                d={path}
+                fill="none"
+                stroke="hsl(var(--border))"
+                strokeWidth={1}
+                className="text-border/60"
+                style={{ stroke: "currentColor" }}
+              />
+            );
+          })}
+        </svg>
+
+        {/* Boxed nodes */}
+        {layout.nodes.map((node) => (
+          <div
+            key={node.agent.id}
+            className="absolute"
+            style={{
+              left: node.x,
+              top: node.y,
+              width: node.w,
+              height: node.h,
+            }}
+          >
+            <AgentNode
+              agent={node.agent}
+              onEdit={onEdit}
+              onTogglePause={onTogglePause}
+              onDelete={onDelete}
+            />
+            {node.hasChildren && (
+              <button
+                type="button"
+                onClick={() => toggleCollapsed(node.agent.id)}
+                className={cn(
+                  "absolute left-1/2 z-10 flex h-4 w-4 -translate-x-1/2 items-center justify-center rounded border border-border/60 bg-background text-muted-foreground transition-colors hover:border-foreground/40 hover:text-foreground",
+                )}
+                style={{ bottom: -8 }}
+                title={collapsed.has(node.agent.id) ? "Expand" : "Collapse"}
+                aria-label={
+                  collapsed.has(node.agent.id) ? "Expand subtree" : "Collapse subtree"
+                }
+              >
+                {collapsed.has(node.agent.id) ? (
+                  <ChevronRight className="h-2.5 w-2.5" />
+                ) : (
+                  <ChevronDown className="h-2.5 w-2.5" />
+                )}
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/agents/agent-org-slice.tsx
+++ b/apps/ui/src/components/agents/agent-org-slice.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { ChevronDown } from "lucide-react";
+import type { Agent, AgentMeta } from "@/lib/agents/types";
+import { AgentNode } from "@/components/agents/agent-node";
+import { sortAgentsByStatus } from "@/components/agents/agent-card";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+interface AgentOrgSliceProps {
+  agent: Agent;
+  allAgents: Agent[];
+  onChangeManager: (newManagerId: string | null) => Promise<void> | void;
+  disabled?: boolean;
+}
+
+/**
+ * Compact 3-row neighborhood for the agent detail sidebar:
+ *   • Manager pill (or "Operator" placeholder) — click to reassign.
+ *   • Self + peers (other directs of the same manager).
+ *   • Direct reports.
+ *
+ * Sized to fit the 280px DetailSidebar.
+ */
+export function AgentOrgSlice({
+  agent,
+  allAgents,
+  onChangeManager,
+  disabled = false,
+}: AgentOrgSliceProps) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  const manager = useMemo(
+    () => allAgents.find((a) => a.id === agent.reports_to_id) ?? null,
+    [allAgents, agent.reports_to_id],
+  );
+
+  const peers = useMemo(() => {
+    const siblings = allAgents.filter(
+      (a) => a.reports_to_id === agent.reports_to_id && a.id !== agent.id,
+    );
+    return sortAgentsByStatus(siblings);
+  }, [allAgents, agent.id, agent.reports_to_id]);
+
+  const directs = useMemo(() => {
+    return sortAgentsByStatus(
+      allAgents.filter((a) => a.reports_to_id === agent.id),
+    );
+  }, [allAgents, agent.id]);
+
+  const managerCandidates = useMemo(
+    () => allAgents.filter((a) => a.id !== agent.id),
+    [allAgents, agent.id],
+  );
+
+  async function pickManager(newId: string | null) {
+    setPickerOpen(false);
+    await onChangeManager(newId);
+  }
+
+  return (
+    <div className="flex flex-col items-stretch gap-1">
+      {/* Manager row */}
+      <div className="flex justify-center">
+        <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              disabled={disabled}
+              className={cn(
+                "group inline-flex h-8 max-w-full items-center gap-2 rounded-md border border-border/60 bg-background px-2 text-[12px] transition-colors hover:bg-muted/30",
+                disabled && "opacity-60",
+              )}
+            >
+              {manager ? (
+                <ManagerLabel manager={manager} />
+              ) : (
+                <span className="text-muted-foreground/70">Operator (you)</span>
+              )}
+              <ChevronDown className="h-3 w-3 shrink-0 text-muted-foreground/60" />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent className="w-56 p-1" align="center">
+            <button
+              type="button"
+              onClick={() => pickManager(null)}
+              className={cn(
+                "flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-[12px] hover:bg-accent",
+                !agent.reports_to_id && "bg-accent/60",
+              )}
+            >
+              <span className="text-muted-foreground/70">Operator (you)</span>
+            </button>
+            {managerCandidates.map((a) => {
+              const meta = (a.meta ?? {}) as AgentMeta;
+              return (
+                <button
+                  key={a.id}
+                  type="button"
+                  onClick={() => pickManager(a.id)}
+                  className={cn(
+                    "flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-[12px] hover:bg-accent",
+                    agent.reports_to_id === a.id && "bg-accent/60",
+                  )}
+                >
+                  {meta.emoji && <span>{meta.emoji}</span>}
+                  <span className="truncate">{a.name}</span>
+                </button>
+              );
+            })}
+          </PopoverContent>
+        </Popover>
+      </div>
+
+      {/* Connector line manager → self */}
+      <div className="flex justify-center" aria-hidden>
+        <div className="h-3 border-l border-border/60" />
+      </div>
+
+      {/* Self + peers row */}
+      <div className="flex flex-wrap items-center justify-center gap-1.5">
+        <AgentNode agent={agent} variant="pill" asSelf className="max-w-full" />
+        {peers.map((peer) => (
+          <AgentNode
+            key={peer.id}
+            agent={peer}
+            variant="pill"
+            className="max-w-full"
+          />
+        ))}
+      </div>
+
+      {/* Connector line self → directs (only when there are directs) */}
+      {directs.length > 0 && (
+        <>
+          <div className="flex justify-center" aria-hidden>
+            <div className="h-3 border-l border-border/60" />
+          </div>
+          <div className="flex flex-wrap items-center justify-center gap-1.5">
+            {directs.map((d) => (
+              <AgentNode
+                key={d.id}
+                agent={d}
+                variant="pill"
+                className="max-w-full"
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function ManagerLabel({ manager }: { manager: Agent }) {
+  const meta = (manager.meta ?? {}) as AgentMeta;
+  return (
+    <span className="flex min-w-0 items-center gap-1.5">
+      {meta.emoji && <span className="shrink-0">{meta.emoji}</span>}
+      <span className="truncate">{manager.name}</span>
+    </span>
+  );
+}

--- a/apps/ui/src/lib/agents/org-layout.ts
+++ b/apps/ui/src/lib/agents/org-layout.ts
@@ -1,0 +1,178 @@
+import type { Agent } from "./types";
+
+export interface OrgLayoutNode {
+  agent: Agent;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  hasChildren: boolean;
+}
+
+export interface OrgLayoutEdge {
+  fromId: string;
+  toId: string;
+}
+
+export interface OrgLayout {
+  nodes: OrgLayoutNode[];
+  edges: OrgLayoutEdge[];
+  width: number;
+  height: number;
+}
+
+export interface OrgLayoutOptions {
+  nodeW?: number;
+  nodeH?: number;
+  gapX?: number;
+  gapY?: number;
+  padX?: number;
+  padY?: number;
+  collapsed?: ReadonlySet<string>;
+  sort?: (a: Agent, b: Agent) => number;
+}
+
+const DEFAULTS = {
+  nodeW: 200,
+  nodeH: 52,
+  gapX: 20,
+  gapY: 36,
+  padX: 16,
+  padY: 8,
+};
+
+/**
+ * Tidy-tree-lite layout for the agent org chart. Multi-rooted forest:
+ * roots are agents whose `reports_to_id` is null OR points outside the
+ * passed-in set. Cycles are broken by tracking visited ids.
+ */
+export function layoutOrgTree(
+  agents: Agent[],
+  opts: OrgLayoutOptions = {},
+): OrgLayout {
+  const nodeW = opts.nodeW ?? DEFAULTS.nodeW;
+  const nodeH = opts.nodeH ?? DEFAULTS.nodeH;
+  const gapX = opts.gapX ?? DEFAULTS.gapX;
+  const gapY = opts.gapY ?? DEFAULTS.gapY;
+  const padX = opts.padX ?? DEFAULTS.padX;
+  const padY = opts.padY ?? DEFAULTS.padY;
+  const collapsed = opts.collapsed ?? new Set<string>();
+  const sort = opts.sort;
+
+  const byId = new Map(agents.map((a) => [a.id, a]));
+  const childrenMap = new Map<string | null, Agent[]>();
+  for (const a of agents) {
+    const rawParent = a.reports_to_id ?? null;
+    const parent = rawParent && byId.has(rawParent) ? rawParent : null;
+    const arr = childrenMap.get(parent) ?? [];
+    arr.push(a);
+    childrenMap.set(parent, arr);
+  }
+  if (sort) {
+    for (const [, list] of childrenMap) list.sort(sort);
+  }
+
+  const roots = childrenMap.get(null) ?? [];
+
+  // First pass: compute subtree width per visited node.
+  const widthCache = new Map<string, number>();
+  function subtreeWidth(id: string, visited: Set<string>): number {
+    if (widthCache.has(id)) return widthCache.get(id)!;
+    if (visited.has(id) || collapsed.has(id)) {
+      widthCache.set(id, nodeW);
+      return nodeW;
+    }
+    visited.add(id);
+    const kids = childrenMap.get(id) ?? [];
+    if (kids.length === 0) {
+      widthCache.set(id, nodeW);
+      visited.delete(id);
+      return nodeW;
+    }
+    const total =
+      kids.reduce((acc, k) => acc + subtreeWidth(k.id, visited), 0) +
+      gapX * (kids.length - 1);
+    const w = Math.max(nodeW, total);
+    widthCache.set(id, w);
+    visited.delete(id);
+    return w;
+  }
+
+  const nodes: OrgLayoutNode[] = [];
+  const edges: OrgLayoutEdge[] = [];
+  const placed = new Set<string>();
+
+  // Second pass: assign x/y via DFS, centering parents over their children.
+  function place(
+    agent: Agent,
+    leftEdge: number,
+    depth: number,
+    visited: Set<string>,
+  ) {
+    if (placed.has(agent.id) || visited.has(agent.id)) return;
+    visited.add(agent.id);
+
+    const isCollapsed = collapsed.has(agent.id);
+    const kids = isCollapsed ? [] : (childrenMap.get(agent.id) ?? []);
+    const totalW = subtreeWidth(agent.id, new Set(visited));
+
+    const x = leftEdge + (totalW - nodeW) / 2;
+    const y = depth * (nodeH + gapY);
+
+    placed.add(agent.id);
+    nodes.push({
+      agent,
+      x,
+      y,
+      w: nodeW,
+      h: nodeH,
+      hasChildren: (childrenMap.get(agent.id) ?? []).length > 0,
+    });
+
+    let cursor = leftEdge;
+    for (const child of kids) {
+      const childW = subtreeWidth(child.id, new Set(visited));
+      edges.push({ fromId: agent.id, toId: child.id });
+      place(child, cursor, depth + 1, visited);
+      cursor += childW + gapX;
+    }
+    visited.delete(agent.id);
+  }
+
+  let cursor = 0;
+  for (const root of roots) {
+    const w = subtreeWidth(root.id, new Set());
+    place(root, cursor, 0, new Set());
+    cursor += w + gapX * 2;
+  }
+
+  // Any agent that wasn't placed (e.g. part of a pure cycle) becomes a
+  // synthetic root so the chart still renders something.
+  for (const a of agents) {
+    if (placed.has(a.id)) continue;
+    const w = subtreeWidth(a.id, new Set());
+    place(a, cursor, 0, new Set());
+    cursor += w + gapX * 2;
+  }
+
+  // Compute bounding box.
+  let maxRight = 0;
+  let maxBottom = 0;
+  for (const n of nodes) {
+    if (n.x + n.w > maxRight) maxRight = n.x + n.w;
+    if (n.y + n.h > maxBottom) maxBottom = n.y + n.h;
+  }
+
+  // Apply outer padding by translating all nodes and growing the canvas.
+  for (const n of nodes) {
+    n.x += padX;
+    n.y += padY;
+  }
+
+  return {
+    nodes,
+    edges,
+    width: maxRight + padX * 2,
+    height: maxBottom + padY * 2,
+  };
+}

--- a/docs-site/concepts/agents.mdx
+++ b/docs-site/concepts/agents.mdx
@@ -186,7 +186,10 @@ Every agent lives on its own git branch. File changes land on disk immediately, 
 
 ## Org chart and delegation
 
-Agents can report to other agents. The `reports_to_id` field creates a lightweight org chart in the agent list and on each agent detail page.
+Agents can report to other agents through `reports_to_id`. The UI surfaces the resulting hierarchy in two places:
+
+- **Agents list** — once at least one agent has a manager, a Fleet / Org chart view toggle appears in the filter bar. The chart lays the reporting tree out as connected boxes; chevron toggles on parent nodes collapse subtrees, and hovering a node reveals the same edit/pause/delete actions as the list view.
+- **Agent detail sidebar** — an "Org" section shows the agent's manager (if any), peers (other direct reports of the same manager), and direct reports. Clicking the manager pill opens a picker for inline reassignment.
 
 When an agent has a manager or direct reports, the HQ bootstrap plugin injects a "Your Position" section into runtime context. That context tells the agent:
 
@@ -196,7 +199,7 @@ When an agent has a manager or direct reports, the HQ bootstrap plugin injects a
 - To escalate by creating high-priority tasks for its manager.
 - To ask the human before routing work to peer agents outside the direct hierarchy.
 
-Cycle prevention is handled before saving manager changes: an agent cannot report to itself, and the UI checks the manager chain so loops cannot be created accidentally.
+Cycle prevention is handled before saving manager changes: an agent cannot report to itself, and the UI walks the manager chain via the `agent_reports_chain` RPC so loops cannot be created accidentally.
 
 ## Model and thinking configuration
 

--- a/docs-site/concepts/features.mdx
+++ b/docs-site/concepts/features.mdx
@@ -145,7 +145,9 @@ Optional git remote sync can push commits to GitHub or another git host for back
 
 Agents can report to other agents through `agents.reports_to_id`. The UI prevents self-reporting and cycle creation.
 
-The hierarchy is visible on the agent list and on each agent detail page. Runtime boot context includes:
+The agents list has a Fleet / Org chart view toggle that appears once at least one agent has a manager. The chart renders the reporting tree as connected boxes with collapsible subtrees. On each agent's detail page, the sidebar shows an "Org" section with the agent's manager, peers, and direct reports — the manager pill opens a picker for inline reassignment.
+
+Runtime boot context includes:
 
 - The agent's manager.
 - The agent's direct reports.

--- a/docs-site/llms-full.txt
+++ b/docs-site/llms-full.txt
@@ -3675,7 +3675,9 @@ Optional git remote sync can push commits to GitHub or another git host for back
 
 Agents can report to other agents through `agents.reports_to_id`. The UI prevents self-reporting and cycle creation.
 
-The hierarchy is visible on the agent list and on each agent detail page. Runtime boot context includes:
+The agents list has a Fleet / Org chart view toggle that appears once at least one agent has a manager. The chart renders the reporting tree as connected boxes with collapsible subtrees. On each agent's detail page, the sidebar shows an "Org" section with the agent's manager, peers, and direct reports — the manager pill opens a picker for inline reassignment.
+
+Runtime boot context includes:
 
 - The agent's manager.
 - The agent's direct reports.
@@ -4368,7 +4370,10 @@ Every agent lives on its own git branch. File changes land on disk immediately, 
 
 ## Org chart and delegation
 
-Agents can report to other agents. The `reports_to_id` field creates a lightweight org chart in the agent list and on each agent detail page.
+Agents can report to other agents through `reports_to_id`. The UI surfaces the resulting hierarchy in two places:
+
+- **Agents list** — once at least one agent has a manager, a Fleet / Org chart view toggle appears in the filter bar. The chart lays the reporting tree out as connected boxes; chevron toggles on parent nodes collapse subtrees, and hovering a node reveals the same edit/pause/delete actions as the list view.
+- **Agent detail sidebar** — an "Org" section shows the agent's manager (if any), peers (other direct reports of the same manager), and direct reports. Clicking the manager pill opens a picker for inline reassignment.
 
 When an agent has a manager or direct reports, the HQ bootstrap plugin injects a "Your Position" section into runtime context. That context tells the agent:
 
@@ -4378,7 +4383,7 @@ When an agent has a manager or direct reports, the HQ bootstrap plugin injects a
 - To escalate by creating high-priority tasks for its manager.
 - To ask the human before routing work to peer agents outside the direct hierarchy.
 
-Cycle prevention is handled before saving manager changes: an agent cannot report to itself, and the UI checks the manager chain so loops cannot be created accidentally.
+Cycle prevention is handled before saving manager changes: an agent cannot report to itself, and the UI walks the manager chain via the `agent_reports_chain` RPC so loops cannot be created accidentally.
 
 ## Model and thinking configuration
 


### PR DESCRIPTION
Replace the indented hierarchy list view with a true boxes-and-lines
org chart (custom SVG, no new deps), switchable from the agents list
page via a ToggleGroup that mirrors the tasks list/board pattern and
persists to localStorage. On the agent detail page, swap the lone
"Manager" property row for a compact 3-row neighborhood slice
(manager pill above, self+peers row in the middle with self
ring-highlighted, direct reports below) so the org context is visible
at a glance and the manager picker is reachable inline.

- Add lib/agents/org-layout.ts (cycle-safe tidy-tree-lite layout).
- Add components/agents/agent-node.tsx (default + pill variants).
- Add components/agents/agent-org-chart.tsx with collapsible subtrees.
- Add components/agents/agent-org-slice.tsx for the sidebar.
- Promote AGENT_STATUS, AgentUsagePill, AgentIconButton from
  agent-card.tsx and drop the now-dead buildAgentTree/AgentTreeNode.

https://claude.ai/code/session_0123DYq2BJ77bWhgyWrkcknQ