### PR TITLE
feat: full new-workspace flow parity with onboarding wizard

### DIFF
--- a/apps/ui/src/__tests__/api/workspace-routes.test.ts
+++ b/apps/ui/src/__tests__/api/workspace-routes.test.ts
@@ -3,6 +3,13 @@ import { NextRequest } from "next/server";
 import { resetServerMocks, getServerClient } from "../helpers/server-mock";
 import "../helpers/server-mock";
 
+const mockTargetAuth = {
+  getUser: vi.fn().mockResolvedValue({ data: { user: { id: "user-1" } }, error: null }),
+};
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: vi.fn(() => ({ auth: mockTargetAuth })),
+}));
+
 vi.mock("@/lib/workspaces/registry", () => ({
   getRegistry: vi.fn().mockResolvedValue({
     workspaces: [],
@@ -239,8 +246,15 @@ describe("POST /api/workspaces/switch", () => {
   });
 
   test("returns 401 when user is not authenticated (OSS mode)", async () => {
-    const client = getServerClient();
-    client.auth.getUser.mockResolvedValue({
+    const { getWorkspace } = await import("@/lib/workspaces/registry");
+    vi.mocked(getWorkspace).mockResolvedValue({
+      id: "550e8400-e29b-41d4-a716-446655440000",
+      label: "Test Workspace",
+      url: "https://test.supabase.co",
+      anonKey: "test-anon-key-that-is-long-enough",
+    } as never);
+
+    mockTargetAuth.getUser.mockResolvedValue({
       data: { user: null },
       error: { message: "Not authenticated" },
     });
@@ -280,8 +294,7 @@ describe("POST /api/workspaces/switch", () => {
   });
 
   test("switches workspace successfully (OSS mode)", async () => {
-    const client = getServerClient();
-    client.auth.getUser.mockResolvedValue({
+    mockTargetAuth.getUser.mockResolvedValue({
       data: { user: { id: "user-1", email: "test@test.com" } },
       error: null,
     });
@@ -290,6 +303,8 @@ describe("POST /api/workspaces/switch", () => {
     vi.mocked(getWorkspace).mockResolvedValue({
       id: "550e8400-e29b-41d4-a716-446655440000",
       label: "Test Workspace",
+      url: "https://test.supabase.co",
+      anonKey: "test-anon-key-that-is-long-enough",
     } as never);
     vi.mocked(setActiveWorkspace).mockResolvedValue(undefined);
 

--- a/apps/ui/src/__tests__/components/workspaces/workspace-switcher.test.tsx
+++ b/apps/ui/src/__tests__/components/workspaces/workspace-switcher.test.tsx
@@ -17,8 +17,8 @@ vi.mock("next/link", () => ({
   ),
 }));
 
-vi.mock("./add-workspace-dialog", () => ({
-  AddWorkspaceDialog: () => null,
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
 }));
 
 import {
@@ -45,7 +45,7 @@ describe("WorkspaceSwitcher", () => {
     expect(screen.getByText("HQ")).toBeInTheDocument();
   });
 
-  it("renders single workspace as static label (no dropdown)", () => {
+  it("renders single workspace with dropdown (always shows switcher)", () => {
     const ws = makeWorkspace();
     render(
       <WorkspaceSwitcher activeWorkspaceId="ws-1" workspaces={[ws]} />
@@ -53,8 +53,8 @@ describe("WorkspaceSwitcher", () => {
     expect(screen.getByText("My Workspace")).toBeInTheDocument();
     expect(screen.getByText("🏠")).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /Switch workspace/ })
-    ).not.toBeInTheDocument();
+      screen.getByRole("button", { name: /Switch workspace/ })
+    ).toBeInTheDocument();
   });
 
   it("renders dropdown trigger when multiple workspaces", () => {

--- a/apps/ui/src/__tests__/lib/agents-roster.test.ts
+++ b/apps/ui/src/__tests__/lib/agents-roster.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import {
+  AGENT_ROSTER,
+  INTENT_TO_AGENT_KEY,
+  type AgentTemplate,
+} from "@/lib/agents/roster";
+
+describe("agent roster", () => {
+  it("exports a non-empty roster", () => {
+    expect(AGENT_ROSTER.length).toBeGreaterThan(0);
+  });
+
+  it("every roster entry has required fields", () => {
+    for (const agent of AGENT_ROSTER) {
+      expect(agent.key).toBeTruthy();
+      expect(agent.branch).toBeTruthy();
+      expect(agent.name).toBeTruthy();
+      expect(agent.emoji).toBeTruthy();
+      expect(agent.role).toBeTruthy();
+      expect(agent.description).toBeTruthy();
+      expect(agent.capabilities.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("has unique keys", () => {
+    const keys = AGENT_ROSTER.map((a) => a.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it("INTENT_TO_AGENT_KEY maps to valid roster keys", () => {
+    const rosterKeys = new Set(AGENT_ROSTER.map((a) => a.key));
+    for (const [intent, agentKey] of Object.entries(INTENT_TO_AGENT_KEY)) {
+      expect(rosterKeys.has(agentKey)).toBe(true);
+    }
+  });
+
+  it("AgentTemplate type is usable", () => {
+    const t: AgentTemplate = AGENT_ROSTER[0];
+    expect(t.key).toBeTruthy();
+  });
+});

--- a/apps/ui/src/__tests__/lib/agents-roster.test.ts
+++ b/apps/ui/src/__tests__/lib/agents-roster.test.ts
@@ -29,7 +29,7 @@ describe("agent roster", () => {
 
   it("INTENT_TO_AGENT_KEY maps to valid roster keys", () => {
     const rosterKeys = new Set(AGENT_ROSTER.map((a) => a.key));
-    for (const [intent, agentKey] of Object.entries(INTENT_TO_AGENT_KEY)) {
+    for (const [, agentKey] of Object.entries(INTENT_TO_AGENT_KEY)) {
       expect(rosterKeys.has(agentKey)).toBe(true);
     }
   });

--- a/apps/ui/src/__tests__/lib/run-complete-setup.test.ts
+++ b/apps/ui/src/__tests__/lib/run-complete-setup.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createMockSupabaseClient } from "@/__tests__/helpers/supabase-mock";
+
+vi.mock("server-only", () => ({}));
+
+describe("runCompleteSetup", () => {
+  let mockSupabase: ReturnType<typeof createMockSupabaseClient>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function importModule() {
+    return import("@/lib/setup/run-complete-setup");
+  }
+
+  it("calls complete_setup RPC with correct params for default preset", async () => {
+    const rpcMock = vi.fn().mockResolvedValue({ error: null });
+    mockSupabase = createMockSupabaseClient({
+      tables: new Map([
+        ["workspace", { update: { data: null, error: null } }],
+      ]),
+      rpcs: new Map(),
+    });
+    mockSupabase.rpc = rpcMock;
+
+    const { runCompleteSetup } = await importModule();
+    const result = await runCompleteSetup(mockSupabase as never, {
+      workspaceName: "Test Workspace",
+      workspaceSlug: "test-ws",
+      ownerName: "Test User",
+      contextPresetKey: null,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(rpcMock).toHaveBeenCalledWith(
+      "complete_setup",
+      expect.objectContaining({
+        p_name: "Test Workspace",
+        p_slug: "test-ws",
+        p_owner_name: "Test User",
+        p_tenant_id: "00000000-0000-0000-0000-000000000000",
+      }),
+    );
+  });
+
+  it("calls complete_setup RPC with reach preset stages", async () => {
+    const rpcMock = vi.fn().mockResolvedValue({ error: null });
+    mockSupabase = createMockSupabaseClient({
+      tables: new Map([
+        ["workspace", { update: { data: null, error: null } }],
+      ]),
+      rpcs: new Map(),
+    });
+    mockSupabase.rpc = rpcMock;
+
+    const { runCompleteSetup } = await importModule();
+    const result = await runCompleteSetup(mockSupabase as never, {
+      workspaceName: "Sales HQ",
+      contextPresetKey: "reach",
+    });
+
+    expect(result.ok).toBe(true);
+    const call = rpcMock.mock.calls[0];
+    expect(call[0]).toBe("complete_setup");
+    const stages = call[1].p_stages;
+    expect(stages.length).toBeGreaterThan(0);
+    expect(stages[0]).toHaveProperty("stage_key");
+    expect(stages[0]).toHaveProperty("label");
+  });
+
+  it("returns error when RPC fails", async () => {
+    const rpcMock = vi.fn().mockResolvedValue({
+      error: { message: "RPC failed" },
+    });
+    mockSupabase = createMockSupabaseClient({
+      tables: new Map(),
+      rpcs: new Map(),
+    });
+    mockSupabase.rpc = rpcMock;
+
+    const { runCompleteSetup } = await importModule();
+    const result = await runCompleteSetup(mockSupabase as never, {
+      workspaceName: "Fail WS",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("RPC failed");
+  });
+
+  it("uses default name when workspaceName is empty", async () => {
+    const rpcMock = vi.fn().mockResolvedValue({ error: null });
+    mockSupabase = createMockSupabaseClient({
+      tables: new Map([
+        ["workspace", { update: { data: null, error: null } }],
+      ]),
+      rpcs: new Map(),
+    });
+    mockSupabase.rpc = rpcMock;
+
+    const { runCompleteSetup } = await importModule();
+    await runCompleteSetup(mockSupabase as never, {
+      workspaceName: "",
+    });
+
+    expect(rpcMock).toHaveBeenCalledWith(
+      "complete_setup",
+      expect.objectContaining({ p_name: "HQ" }),
+    );
+  });
+
+  it("sets preferredName to ownerName when not provided", async () => {
+    const rpcMock = vi.fn().mockResolvedValue({ error: null });
+    mockSupabase = createMockSupabaseClient({
+      tables: new Map([
+        ["workspace", { update: { data: null, error: null } }],
+      ]),
+      rpcs: new Map(),
+    });
+    mockSupabase.rpc = rpcMock;
+
+    const { runCompleteSetup } = await importModule();
+    await runCompleteSetup(mockSupabase as never, {
+      workspaceName: "WS",
+      ownerName: "Alice",
+    });
+
+    expect(rpcMock).toHaveBeenCalledWith(
+      "complete_setup",
+      expect.objectContaining({
+        p_owner_name: "Alice",
+        p_preferred_name: "Alice",
+      }),
+    );
+  });
+});

--- a/apps/ui/src/app/api/workspaces/switch/route.ts
+++ b/apps/ui/src/app/api/workspaces/switch/route.ts
@@ -5,8 +5,8 @@
 
 import { NextResponse, type NextRequest } from "next/server";
 import { cookies } from "next/headers";
+import { createServerClient } from "@supabase/ssr";
 import { z } from "zod";
-import { createClient } from "@/lib/supabase/server";
 import { getWorkspace, setActiveWorkspace } from "@/lib/workspaces/registry";
 import {
   ACTIVE_WORKSPACE_COOKIE,
@@ -47,19 +47,41 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ ok: true, workspaceId: parsed.data.workspaceId });
   }
 
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
   const workspace = await getWorkspace(parsed.data.workspaceId);
   if (!workspace) {
     return NextResponse.json({ error: "Workspace not found" }, { status: 404 });
   }
-  await setActiveWorkspace(parsed.data.workspaceId);
+
   const jar = await cookies();
+  const cookiePrefix = `hq-${workspace.id.slice(0, 8)}`;
+
+  const targetSupabase = createServerClient(workspace.url, workspace.anonKey, {
+    cookieOptions: { name: cookiePrefix },
+    cookies: {
+      getAll() {
+        return jar.getAll();
+      },
+      setAll(cookiesToSet) {
+        try {
+          cookiesToSet.forEach(({ name, value, options }) =>
+            jar.set(name, value, options),
+          );
+        } catch {
+          // Called from a context where cookies can't be set — safe to ignore.
+        }
+      },
+    },
+  });
+
+  const {
+    data: { user },
+  } = await targetSupabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  await setActiveWorkspace(parsed.data.workspaceId);
   jar.set(
     ACTIVE_WORKSPACE_COOKIE,
     parsed.data.workspaceId,

--- a/apps/ui/src/app/login/actions.ts
+++ b/apps/ui/src/app/login/actions.ts
@@ -2,11 +2,17 @@
 
 import { cookies, headers } from "next/headers";
 import { createClient as createSupabaseClient } from "@supabase/supabase-js";
+import { createServerClient } from "@supabase/ssr";
 import {
   createWorkspaceSessionValue,
   lookupUserWorkspaces,
 } from "@/lib/workspaces/hosted-registry";
 import { workerFetch } from "@/lib/worker-client";
+import { getRegistry } from "@/lib/workspaces/registry";
+import {
+  ACTIVE_WORKSPACE_COOKIE,
+  ACTIVE_WORKSPACE_COOKIE_OPTIONS,
+} from "@/lib/workspaces/cookie";
 
 export async function hostedLoginAction(email: string): Promise<{
   ok: boolean;
@@ -52,4 +58,86 @@ export async function hostedLoginAction(email: string): Promise<{
   workerFetch(`/workspaces/${ws.id}/touch`, { method: "POST" }).catch(() => {});
 
   return { ok: true };
+}
+
+export async function loginAcrossWorkspaces(
+  email: string,
+  password: string,
+): Promise<{
+  ok: boolean;
+  error?: string;
+  activeWorkspaceId?: string;
+  matchedWorkspaceIds: string[];
+}> {
+  const registry = await getRegistry();
+  if (registry.workspaces.length === 0) {
+    return { ok: false, error: "No workspaces configured.", matchedWorkspaceIds: [] };
+  }
+
+  const jar = await cookies();
+  const currentActiveId = jar.get(ACTIVE_WORKSPACE_COOKIE)?.value ?? null;
+
+  const pendingCookies: Array<{ name: string; value: string; options: Record<string, unknown> }> = [];
+
+  const results = await Promise.allSettled(
+    registry.workspaces.map(async (workspace) => {
+      const cookiePrefix = `hq-${workspace.id.slice(0, 8)}`;
+
+      const supabase = createServerClient(workspace.url, workspace.anonKey, {
+        cookieOptions: { name: cookiePrefix },
+        cookies: {
+          getAll() {
+            return jar.getAll();
+          },
+          setAll(cookiesToSet) {
+            for (const cookie of cookiesToSet) {
+              pendingCookies.push(cookie);
+            }
+          },
+        },
+      });
+
+      const { error } = await supabase.auth.signInWithPassword({
+        email,
+        password,
+      });
+
+      if (error) {
+        throw error;
+      }
+
+      return workspace.id;
+    }),
+  );
+
+  const matchedIds: string[] = [];
+  for (const r of results) {
+    if (r.status === "fulfilled") {
+      matchedIds.push(r.value);
+    }
+  }
+
+  if (matchedIds.length === 0) {
+    return {
+      ok: false,
+      error: "Invalid login credentials",
+      matchedWorkspaceIds: [],
+    };
+  }
+
+  for (const cookie of pendingCookies) {
+    jar.set(cookie.name, cookie.value, cookie.options);
+  }
+
+  const landingId = currentActiveId && matchedIds.includes(currentActiveId)
+    ? currentActiveId
+    : matchedIds[0];
+
+  jar.set(ACTIVE_WORKSPACE_COOKIE, landingId, ACTIVE_WORKSPACE_COOKIE_OPTIONS);
+
+  return {
+    ok: true,
+    activeWorkspaceId: landingId,
+    matchedWorkspaceIds: matchedIds,
+  };
 }

--- a/apps/ui/src/app/login/login-form.tsx
+++ b/apps/ui/src/app/login/login-form.tsx
@@ -1,12 +1,11 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { createClient } from "@/lib/supabase/client";
 import { useRouter } from "next/navigation";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Sparkles, AlertCircle, Check, ArrowRight, Mail } from "lucide-react";
-import { hostedLoginAction } from "./actions";
+import { hostedLoginAction, loginAcrossWorkspaces } from "./actions";
 import { cn } from "@/lib/utils";
 import { trackEvent, identifyUser } from "@/lib/analytics";
 
@@ -29,28 +28,20 @@ export function LoginForm({ mode }: { mode: "oss" | "hosted" }) {
     setError(null);
     trackEvent("login_submitted", { mode: "oss" });
 
-    let supabase;
-    try {
-      supabase = createClient();
-    } catch {
-      setError("Workspace not configured — complete setup first.");
-      setLoading(false);
-      return;
-    }
-    const { error } = await supabase.auth.signInWithPassword({
-      email,
-      password,
-    });
+    const result = await loginAcrossWorkspaces(email, password);
 
-    if (error) {
-      trackEvent("login_failed", { mode: "oss", error: error.message });
-      setError(error.message);
+    if (!result.ok) {
+      trackEvent("login_failed", { mode: "oss", error: result.error });
+      setError(result.error ?? "Something went wrong.");
       setLoading(false);
       return;
     }
 
     identifyUser(email, { email });
-    trackEvent("login_succeeded", { mode: "oss" });
+    trackEvent("login_succeeded", {
+      mode: "oss",
+      matchedWorkspaces: result.matchedWorkspaceIds.length,
+    });
     router.push("/dashboard");
     router.refresh();
   }

--- a/apps/ui/src/app/new-workspace/actions.ts
+++ b/apps/ui/src/app/new-workspace/actions.ts
@@ -311,28 +311,34 @@ export async function registerNewWorkspaceDb(input: {
 export async function mintNewWorkspaceGatewayToken(input?: {
   label?: string;
 }): Promise<ActionResult<{ oneLiner: string; tokenId: string; expiresAt: string }>> {
-  const workspace = await getActiveWorkspaceWithSecrets();
-  if (!workspace) {
-    return { ok: false, error: "No workspace configured yet. Connect a database first." };
+  try {
+    const jar = await cookies();
+    const hint = jar.get(ACTIVE_WORKSPACE_COOKIE)?.value ?? null;
+    const workspace = await getActiveWorkspaceWithSecrets(hint);
+    if (!workspace) {
+      return { ok: false, error: "No workspace configured yet. Connect a database first." };
+    }
+
+    const label = (input?.label ?? "Gateway").trim() || "Gateway";
+    const minted = await mintGatewayToken({ label });
+
+    const oneLiner = buildGatewayOneLiner({
+      token: minted.token,
+      label,
+      project: workspace,
+    });
+
+    return {
+      ok: true,
+      data: {
+        oneLiner,
+        tokenId: minted.tokenId,
+        expiresAt: minted.expiresAt,
+      },
+    };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
   }
-
-  const label = (input?.label ?? "Gateway").trim() || "Gateway";
-  const minted = await mintGatewayToken({ label });
-
-  const oneLiner = buildGatewayOneLiner({
-    token: minted.token,
-    label,
-    project: workspace,
-  });
-
-  return {
-    ok: true,
-    data: {
-      oneLiner,
-      tokenId: minted.tokenId,
-      expiresAt: minted.expiresAt,
-    },
-  };
 }
 
 // ─── (c) Poll for gateway heartbeat ─────────────────────────────────────
@@ -759,7 +765,9 @@ export async function finalizeNewWorkspace(input: {
   workspaceSlug?: string | null;
   ownerName?: string;
 }): Promise<ActionResult> {
-  const workspace = await getActiveWorkspaceWithSecrets();
+  const jar = await cookies();
+  const hint = jar.get(ACTIVE_WORKSPACE_COOKIE)?.value ?? null;
+  const workspace = await getActiveWorkspaceWithSecrets(hint);
   if (!workspace) {
     return { ok: false, error: "No workspace configured. Connect a database first." };
   }

--- a/apps/ui/src/app/new-workspace/actions.ts
+++ b/apps/ui/src/app/new-workspace/actions.ts
@@ -4,6 +4,7 @@ import { cookies, headers } from "next/headers";
 import { randomBytes, createHash } from "crypto";
 import { z } from "zod";
 import { createClient as createSupabaseClient } from "@supabase/supabase-js";
+import { createServerClient } from "@supabase/ssr";
 import { addWorkspace, getWorkspace, getWorkspaceSecrets } from "@/lib/workspaces/registry";
 import { getPostHogClient } from "@/lib/posthog-server";
 import {
@@ -838,6 +839,27 @@ export async function finalizeNewWorkspace(
   }
 
   const jar = await cookies();
+
+  const cookiePrefix = `hq-${workspaceId.slice(0, 8)}`;
+  const authClient = createServerClient(ws.url, ws.anonKey, {
+    cookieOptions: { name: cookiePrefix },
+    cookies: {
+      getAll() {
+        return jar.getAll();
+      },
+      setAll(cookiesToSet) {
+        for (const cookie of cookiesToSet) {
+          jar.set(cookie.name, cookie.value, cookie.options);
+        }
+      },
+    },
+  });
+
+  await authClient.auth.signInWithPassword({
+    email: input.email,
+    password: input.password,
+  });
+
   jar.set(ACTIVE_WORKSPACE_COOKIE, workspaceId, ACTIVE_WORKSPACE_COOKIE_OPTIONS);
 
   return { ok: true };

--- a/apps/ui/src/app/new-workspace/actions.ts
+++ b/apps/ui/src/app/new-workspace/actions.ts
@@ -1,8 +1,10 @@
 "use server";
 
 import { cookies, headers } from "next/headers";
+import { randomBytes, createHash } from "crypto";
 import { z } from "zod";
-import { addWorkspace, getActiveWorkspaceWithSecrets } from "@/lib/workspaces/registry";
+import { createClient as createSupabaseClient } from "@supabase/supabase-js";
+import { addWorkspace, getWorkspace, getWorkspaceSecrets } from "@/lib/workspaces/registry";
 import { getPostHogClient } from "@/lib/posthog-server";
 import {
   ACTIVE_WORKSPACE_COOKIE,
@@ -15,12 +17,24 @@ import { workerFetch } from "@/lib/worker-client";
 import {
   createWorkspaceSessionValue,
 } from "@/lib/workspaces/hosted-registry";
-import { createAdminClient } from "@/lib/supabase/admin";
-import { mintGatewayToken } from "@/lib/gateways/mint-token";
 import { buildGatewayOneLiner } from "@/lib/gateways/one-liner";
 import { dockerAvailable, startLocalGateway, localGatewayStatus } from "@/lib/gateways/local-compose";
 import { runCompleteSetup } from "@/lib/setup/run-complete-setup";
 import { parseSupabaseUrl } from "@/lib/workspaces/parse-url";
+
+async function getWorkspaceWithSecretsById(workspaceId: string) {
+  const workspace = await getWorkspace(workspaceId);
+  if (!workspace) throw new Error(`Workspace ${workspaceId} not found in registry`);
+  const secrets = await getWorkspaceSecrets(workspaceId);
+  if (!secrets) throw new Error(`Secrets for workspace ${workspaceId} not found`);
+  return { ...workspace, ...secrets };
+}
+
+function createAdminClientForWorkspace(url: string, serviceRoleKey: string) {
+  return createSupabaseClient(url, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
 
 interface ActionResult<T = undefined> {
   ok: boolean;
@@ -300,40 +314,51 @@ export async function registerNewWorkspaceDb(input: {
     makeDefault: false,
   });
 
-  const jar = await cookies();
-  jar.set(ACTIVE_WORKSPACE_COOKIE, workspace.id, ACTIVE_WORKSPACE_COOKIE_OPTIONS);
-
   return { ok: true, data: { workspaceId: workspace.id } };
 }
 
 // ─── (b) Mint gateway token ─────────────────────────────────────────────
 
-export async function mintNewWorkspaceGatewayToken(input?: {
-  label?: string;
-}): Promise<ActionResult<{ oneLiner: string; tokenId: string; expiresAt: string }>> {
+export async function mintNewWorkspaceGatewayToken(
+  workspaceId: string,
+  input?: { label?: string },
+): Promise<ActionResult<{ oneLiner: string; tokenId: string; expiresAt: string }>> {
   try {
-    const jar = await cookies();
-    const hint = jar.get(ACTIVE_WORKSPACE_COOKIE)?.value ?? null;
-    const workspace = await getActiveWorkspaceWithSecrets(hint);
-    if (!workspace) {
-      return { ok: false, error: "No workspace configured yet. Connect a database first." };
-    }
+    const ws = await getWorkspaceWithSecretsById(workspaceId);
+    const supabase = createAdminClientForWorkspace(ws.url, ws.serviceRoleKey);
 
     const label = (input?.label ?? "Gateway").trim() || "Gateway";
-    const minted = await mintGatewayToken({ label });
+    const plaintext = randomBytes(24).toString("hex");
+    const tokenHash = createHash("sha256").update(plaintext).digest("hex");
+    const ttl = 15;
+    const expiresAt = new Date(Date.now() + ttl * 60 * 1000).toISOString();
+
+    const { data, error } = await supabase
+      .from("gateway_registration_tokens")
+      .insert({
+        token_hash: tokenHash,
+        label,
+        expires_at: expiresAt,
+      })
+      .select("id, expires_at")
+      .single();
+
+    if (error || !data) {
+      throw new Error(`Failed to mint gateway token: ${error?.message ?? "unknown error"}`);
+    }
 
     const oneLiner = buildGatewayOneLiner({
-      token: minted.token,
+      token: plaintext,
       label,
-      project: workspace,
+      project: ws,
     });
 
     return {
       ok: true,
       data: {
         oneLiner,
-        tokenId: minted.tokenId,
-        expiresAt: minted.expiresAt,
+        tokenId: data.id as string,
+        expiresAt: data.expires_at as string,
       },
     };
   } catch (err) {
@@ -343,11 +368,14 @@ export async function mintNewWorkspaceGatewayToken(input?: {
 
 // ─── (c) Poll for gateway heartbeat ─────────────────────────────────────
 
-export async function pollNewWorkspaceGateway(): Promise<
+export async function pollNewWorkspaceGateway(
+  workspaceId: string,
+): Promise<
   ActionResult<{ status: "ready" | "pending"; gatewayId?: string }>
 > {
   try {
-    const supabase = await createAdminClient();
+    const ws = await getWorkspaceWithSecretsById(workspaceId);
+    const supabase = createAdminClientForWorkspace(ws.url, ws.serviceRoleKey);
     const { data } = await supabase
       .from("gateways")
       .select("id, status, last_seen_at, last_heartbeat_at")
@@ -468,6 +496,7 @@ const OAUTH_PROVIDERS = new Set([
 ]);
 
 export async function connectNewWorkspaceProvider(
+  workspaceId: string,
   provider: string,
   apiKey: string,
 ): Promise<ActionResult> {
@@ -492,7 +521,8 @@ export async function connectNewWorkspaceProvider(
   }
 
   try {
-    const supabase = await createAdminClient();
+    const ws = await getWorkspaceWithSecretsById(workspaceId);
+    const supabase = createAdminClientForWorkspace(ws.url, ws.serviceRoleKey);
     const { data: gw } = await supabase
       .from("gateways")
       .select("id")
@@ -528,11 +558,13 @@ export async function connectNewWorkspaceProvider(
 }
 
 export async function startNewWorkspaceOAuth(
+  workspaceId: string,
   provider: string,
   mode: "oauth_paste" | "device_code",
 ): Promise<ActionResult<{ commandId: string }>> {
   try {
-    const supabase = await createAdminClient();
+    const ws = await getWorkspaceWithSecretsById(workspaceId);
+    const supabase = createAdminClientForWorkspace(ws.url, ws.serviceRoleKey);
     const { data: gw } = await supabase
       .from("gateways")
       .select("id")
@@ -563,11 +595,13 @@ export async function startNewWorkspaceOAuth(
 }
 
 export async function submitNewWorkspaceOAuthPaste(
+  workspaceId: string,
   parentCommandId: string,
   value: string,
 ): Promise<ActionResult> {
   try {
-    const supabase = await createAdminClient();
+    const ws = await getWorkspaceWithSecretsById(workspaceId);
+    const supabase = createAdminClientForWorkspace(ws.url, ws.serviceRoleKey);
     const { data: gw } = await supabase
       .from("gateways")
       .select("id")
@@ -596,9 +630,11 @@ export async function submitNewWorkspaceOAuthPaste(
 }
 
 export async function pollNewWorkspaceCommandState(
+  workspaceId: string,
   commandId: string,
 ): Promise<ActionResult<{ status: string; payload: Record<string, unknown> }>> {
-  const supabase = await createAdminClient();
+  const ws = await getWorkspaceWithSecretsById(workspaceId);
+  const supabase = createAdminClientForWorkspace(ws.url, ws.serviceRoleKey);
   const { data, error } = await supabase
     .from("agent_commands")
     .select("status, payload, error_message")
@@ -619,10 +655,12 @@ export async function pollNewWorkspaceCommandState(
 }
 
 export async function saveNewWorkspaceOAuthProvider(
-  provider: string,
+  workspaceId: string,
+  _provider: string,
 ): Promise<ActionResult> {
   try {
-    const supabase = await createAdminClient();
+    const ws = await getWorkspaceWithSecretsById(workspaceId);
+    const supabase = createAdminClientForWorkspace(ws.url, ws.serviceRoleKey);
     const { data: gw } = await supabase
       .from("gateways")
       .select("id")
@@ -655,13 +693,16 @@ const PROVIDER_DEFAULT_MODELS: Record<string, string> = {
   sglang: "sglang/default",
 };
 
-export async function createNewWorkspaceAgent(input: {
-  agentName: string;
-  agentSlug?: string;
-  agentEmoji: string;
-  templateBranch: string;
-  providerId?: string;
-}): Promise<ActionResult<{ agentId: string; provisionCommandId?: string }>> {
+export async function createNewWorkspaceAgent(
+  workspaceId: string,
+  input: {
+    agentName: string;
+    agentSlug?: string;
+    agentEmoji: string;
+    templateBranch: string;
+    providerId?: string;
+  },
+): Promise<ActionResult<{ agentId: string; provisionCommandId?: string }>> {
   const slug = (input.agentSlug ?? input.agentName)
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
@@ -669,7 +710,8 @@ export async function createNewWorkspaceAgent(input: {
     .slice(0, 30) || "agent";
 
   try {
-    const supabase = await createAdminClient();
+    const ws = await getWorkspaceWithSecretsById(workspaceId);
+    const supabase = createAdminClientForWorkspace(ws.url, ws.serviceRoleKey);
 
     const { data: wsRow } = await supabase
       .from("workspace")
@@ -740,9 +782,11 @@ export async function createNewWorkspaceAgent(input: {
 }
 
 export async function pollNewWorkspaceAgentProvision(
+  workspaceId: string,
   commandId: string,
 ): Promise<"pending" | "completed" | "error"> {
-  const supabase = await createAdminClient();
+  const ws = await getWorkspaceWithSecretsById(workspaceId);
+  const supabase = createAdminClientForWorkspace(ws.url, ws.serviceRoleKey);
   const { data } = await supabase
     .from("agent_commands")
     .select("status")
@@ -757,24 +801,23 @@ export async function pollNewWorkspaceAgentProvision(
 
 // ─── (g) Finalize new workspace ─────────────────────────────────────────
 
-export async function finalizeNewWorkspace(input: {
-  email: string;
-  password: string;
-  contextPresetKey?: string | null;
-  workspaceName: string;
-  workspaceSlug?: string | null;
-  ownerName?: string;
-}): Promise<ActionResult> {
-  const jar = await cookies();
-  const hint = jar.get(ACTIVE_WORKSPACE_COOKIE)?.value ?? null;
-  const workspace = await getActiveWorkspaceWithSecrets(hint);
-  if (!workspace) {
-    return { ok: false, error: "No workspace configured. Connect a database first." };
-  }
+export async function finalizeNewWorkspace(
+  workspaceId: string,
+  input: {
+    email: string;
+    password: string;
+    contextPresetKey?: string | null;
+    workspaceName: string;
+    workspaceSlug?: string | null;
+    ownerName?: string;
+  },
+): Promise<ActionResult> {
+  const ws = await getWorkspaceWithSecretsById(workspaceId);
+  const supabase = createAdminClientForWorkspace(ws.url, ws.serviceRoleKey);
 
   const userResult = await createAuthUser({
-    url: workspace.url,
-    serviceRoleKey: workspace.serviceRoleKey,
+    url: ws.url,
+    serviceRoleKey: ws.serviceRoleKey,
     email: input.email,
     password: input.password,
   });
@@ -783,7 +826,6 @@ export async function finalizeNewWorkspace(input: {
     return { ok: false, error: userResult.error ?? "Failed to create account" };
   }
 
-  const supabase = await createAdminClient();
   const result = await runCompleteSetup(supabase, {
     workspaceName: input.workspaceName,
     workspaceSlug: input.workspaceSlug,
@@ -794,6 +836,9 @@ export async function finalizeNewWorkspace(input: {
   if (!result.ok) {
     return { ok: false, error: result.error };
   }
+
+  const jar = await cookies();
+  jar.set(ACTIVE_WORKSPACE_COOKIE, workspaceId, ACTIVE_WORKSPACE_COOKIE_OPTIONS);
 
   return { ok: true };
 }

--- a/apps/ui/src/app/new-workspace/actions.ts
+++ b/apps/ui/src/app/new-workspace/actions.ts
@@ -2,7 +2,7 @@
 
 import { cookies, headers } from "next/headers";
 import { z } from "zod";
-import { addWorkspace } from "@/lib/workspaces/registry";
+import { addWorkspace, getActiveWorkspaceWithSecrets } from "@/lib/workspaces/registry";
 import { getPostHogClient } from "@/lib/posthog-server";
 import {
   ACTIVE_WORKSPACE_COOKIE,
@@ -15,6 +15,11 @@ import { workerFetch } from "@/lib/worker-client";
 import {
   createWorkspaceSessionValue,
 } from "@/lib/workspaces/hosted-registry";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { mintGatewayToken } from "@/lib/gateways/mint-token";
+import { buildGatewayOneLiner } from "@/lib/gateways/one-liner";
+import { dockerAvailable, startLocalGateway, localGatewayStatus } from "@/lib/gateways/local-compose";
+import { runCompleteSetup } from "@/lib/setup/run-complete-setup";
 
 interface ActionResult<T = undefined> {
   ok: boolean;
@@ -28,6 +33,8 @@ const dbSchema = z.object({
   anonKey: z.string().min(20),
   serviceRoleKey: z.string().min(20),
 });
+
+// ─── Existing actions (kept) ────────────────────────────────────────────
 
 export async function validateNewWorkspaceDb(input: {
   url: string;
@@ -104,7 +111,7 @@ export async function createOssWorkspace(input: {
 
   const workspace = await addWorkspace({
     label: input.label || "My Workspace",
-    emoji: input.emoji || "🏠",
+    emoji: input.emoji || "\u{1F3E0}",
     url: parsed.data.url,
     anonKey: parsed.data.anonKey,
     serviceRoleKey: parsed.data.serviceRoleKey,
@@ -186,4 +193,517 @@ export async function createHostedWorkspaceCheckout(params: {
   });
 
   return { url: data.url, workspaceId: data.workspaceId };
+}
+
+// ─── (a) Register new workspace DB ──────────────────────────────────────
+
+export async function registerNewWorkspaceDb(input: {
+  label: string;
+  emoji: string;
+  url: string;
+  anonKey: string;
+  serviceRoleKey: string;
+}): Promise<ActionResult<{ workspaceId: string }>> {
+  const parsed = dbSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: "Invalid database credentials" };
+  }
+
+  const workspace = await addWorkspace({
+    label: input.label || "My Workspace",
+    emoji: input.emoji || "\u{1F3E0}",
+    url: parsed.data.url,
+    anonKey: parsed.data.anonKey,
+    serviceRoleKey: parsed.data.serviceRoleKey,
+    makeDefault: false,
+  });
+
+  const jar = await cookies();
+  jar.set(ACTIVE_WORKSPACE_COOKIE, workspace.id, ACTIVE_WORKSPACE_COOKIE_OPTIONS);
+
+  return { ok: true, data: { workspaceId: workspace.id } };
+}
+
+// ─── (b) Mint gateway token ─────────────────────────────────────────────
+
+export async function mintNewWorkspaceGatewayToken(input?: {
+  label?: string;
+}): Promise<ActionResult<{ oneLiner: string; tokenId: string; expiresAt: string }>> {
+  const workspace = await getActiveWorkspaceWithSecrets();
+  if (!workspace) {
+    return { ok: false, error: "No workspace configured yet. Connect a database first." };
+  }
+
+  const label = (input?.label ?? "Gateway").trim() || "Gateway";
+  const minted = await mintGatewayToken({ label });
+
+  const oneLiner = buildGatewayOneLiner({
+    token: minted.token,
+    label,
+    project: workspace,
+  });
+
+  return {
+    ok: true,
+    data: {
+      oneLiner,
+      tokenId: minted.tokenId,
+      expiresAt: minted.expiresAt,
+    },
+  };
+}
+
+// ─── (c) Poll for gateway heartbeat ─────────────────────────────────────
+
+export async function pollNewWorkspaceGateway(): Promise<
+  ActionResult<{ status: "ready" | "pending"; gatewayId?: string }>
+> {
+  try {
+    const supabase = await createAdminClient();
+    const { data } = await supabase
+      .from("gateways")
+      .select("id, status, last_seen_at, last_heartbeat_at")
+      .neq("status", "error")
+      .order("last_seen_at", { ascending: false, nullsFirst: false })
+      .limit(1)
+      .maybeSingle();
+    if (data?.id && data.last_seen_at) {
+      const seenAge = Date.now() - new Date(data.last_seen_at as string).getTime();
+      const heartbeatAt = data.last_heartbeat_at as string | null;
+      const heartbeatAge = heartbeatAt
+        ? Date.now() - new Date(heartbeatAt).getTime()
+        : Infinity;
+      if (seenAge < 120_000 && heartbeatAge < 120_000) {
+        return { ok: true, data: { status: "ready", gatewayId: data.id as string } };
+      }
+    }
+  } catch {
+    // fall through
+  }
+
+  const status = await localGatewayStatus();
+  if (status.running) {
+    return { ok: true, data: { status: "ready" } };
+  }
+
+  return { ok: true, data: { status: "pending" } };
+}
+
+// ─── (d) Start local gateway ────────────────────────────────────────────
+
+export async function startLocalNewWorkspaceGateway(): Promise<ActionResult> {
+  const available = await dockerAvailable();
+  if (!available) {
+    return {
+      ok: false,
+      error: "Could not talk to Docker.",
+      hint:
+        "Make sure Docker is running and /var/run/docker.sock is accessible. " +
+        "You can also start the gateway manually: `docker compose --profile gateway up -d`",
+    };
+  }
+
+  const result = await startLocalGateway();
+  if (!result.ok) {
+    return {
+      ok: false,
+      error: `Docker compose failed: ${result.stderr || result.stdout}`.slice(0, 400),
+    };
+  }
+
+  return { ok: true };
+}
+
+// ─── (e) Provider OAuth actions (no onboarding guard) ───────────────────
+
+const PROVIDER_VALIDATION_ENDPOINTS: Record<string, { url: string; method?: string; headers: (key: string) => Record<string, string>; body?: string; authStatuses: number[] }> = {
+  openai: {
+    url: "https://api.openai.com/v1/models",
+    headers: (key) => ({ Authorization: `Bearer ${key}` }),
+    authStatuses: [401, 403],
+  },
+  anthropic: {
+    url: "https://api.anthropic.com/v1/messages",
+    method: "POST",
+    headers: (key) => ({ "x-api-key": key, "anthropic-version": "2023-06-01", "content-type": "application/json" }),
+    body: JSON.stringify({ model: "claude-haiku-4-5-20251001", max_tokens: 1, messages: [{ role: "user", content: "hi" }] }),
+    authStatuses: [401, 403],
+  },
+  google: {
+    url: "https://generativelanguage.googleapis.com/v1beta/models",
+    headers: (key) => ({ "x-goog-api-key": key }),
+    authStatuses: [400, 401, 403],
+  },
+  openrouter: {
+    url: "https://openrouter.ai/api/v1/models",
+    headers: (key) => ({ Authorization: `Bearer ${key}` }),
+    authStatuses: [401, 403],
+  },
+  deepseek: {
+    url: "https://api.deepseek.com/models",
+    headers: (key) => ({ Authorization: `Bearer ${key}` }),
+    authStatuses: [401, 403],
+  },
+  mistral: {
+    url: "https://api.mistral.ai/v1/models",
+    headers: (key) => ({ Authorization: `Bearer ${key}` }),
+    authStatuses: [401, 403],
+  },
+  groq: {
+    url: "https://api.groq.com/openai/v1/models",
+    headers: (key) => ({ Authorization: `Bearer ${key}` }),
+    authStatuses: [401, 403],
+  },
+  xai: {
+    url: "https://api.x.ai/v1/models",
+    headers: (key) => ({ Authorization: `Bearer ${key}` }),
+    authStatuses: [401, 403],
+  },
+  together: {
+    url: "https://api.together.xyz/v1/models",
+    headers: (key) => ({ Authorization: `Bearer ${key}` }),
+    authStatuses: [401, 403],
+  },
+  fireworks: {
+    url: "https://api.fireworks.ai/inference/v1/models",
+    headers: (key) => ({ Authorization: `Bearer ${key}` }),
+    authStatuses: [401, 403],
+  },
+};
+
+const SKIP_VALIDATION_PROVIDERS = new Set([
+  "ollama", "lmstudio", "vllm", "sglang",
+]);
+
+const OAUTH_PROVIDERS = new Set([
+  "openai-codex", "github-copilot", "google-gemini-cli", "minimax-portal",
+]);
+
+export async function connectNewWorkspaceProvider(
+  provider: string,
+  apiKey: string,
+): Promise<ActionResult> {
+  if (SKIP_VALIDATION_PROVIDERS.has(provider) || OAUTH_PROVIDERS.has(provider)) {
+    return { ok: true };
+  }
+
+  const validation = PROVIDER_VALIDATION_ENDPOINTS[provider];
+  if (validation) {
+    try {
+      const res = await fetch(validation.url, {
+        method: validation.method ?? "GET",
+        headers: validation.headers(apiKey),
+        ...(validation.body ? { body: validation.body } : {}),
+      });
+      if (validation.authStatuses.includes(res.status)) {
+        return { ok: false, error: "Invalid API key" };
+      }
+    } catch {
+      return { ok: false, error: "Could not reach the provider API" };
+    }
+  }
+
+  try {
+    const supabase = await createAdminClient();
+    const { data: gw } = await supabase
+      .from("gateways")
+      .select("id")
+      .order("last_seen_at", { ascending: false, nullsFirst: false })
+      .limit(1)
+      .maybeSingle();
+
+    const { error } = await supabase
+      .from("agent_commands")
+      .insert({
+        gateway_id: gw?.id ?? null,
+        action: "auth_set_api_key",
+        payload: { provider, api_key: apiKey },
+      });
+
+    if (error) {
+      return { ok: false, error: error.message };
+    }
+
+    await supabase.from("agent_commands").insert({
+      gateway_id: gw?.id ?? null,
+      action: "auth_list",
+      payload: {},
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : "Failed to save provider",
+    };
+  }
+
+  return { ok: true };
+}
+
+export async function startNewWorkspaceOAuth(
+  provider: string,
+  mode: "oauth_paste" | "device_code",
+): Promise<ActionResult<{ commandId: string }>> {
+  try {
+    const supabase = await createAdminClient();
+    const { data: gw } = await supabase
+      .from("gateways")
+      .select("id")
+      .order("last_seen_at", { ascending: false, nullsFirst: false })
+      .limit(1)
+      .maybeSingle();
+
+    const { data: cmd, error } = await supabase
+      .from("agent_commands")
+      .insert({
+        gateway_id: gw?.id ?? null,
+        action: "auth_start",
+        payload: { provider, profile_name: "default", mode },
+      })
+      .select("id")
+      .single();
+
+    if (error || !cmd) {
+      return { ok: false, error: error?.message ?? "Failed to start sign-in" };
+    }
+    return { ok: true, data: { commandId: cmd.id } };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : "Failed to start sign-in",
+    };
+  }
+}
+
+export async function submitNewWorkspaceOAuthPaste(
+  parentCommandId: string,
+  value: string,
+): Promise<ActionResult> {
+  try {
+    const supabase = await createAdminClient();
+    const { data: gw } = await supabase
+      .from("gateways")
+      .select("id")
+      .order("last_seen_at", { ascending: false, nullsFirst: false })
+      .limit(1)
+      .maybeSingle();
+
+    const { error } = await supabase
+      .from("agent_commands")
+      .insert({
+        gateway_id: gw?.id ?? null,
+        action: "auth_paste",
+        payload: { parent_command_id: parentCommandId, value },
+      });
+
+    if (error) {
+      return { ok: false, error: error.message };
+    }
+    return { ok: true };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : "Failed to submit code",
+    };
+  }
+}
+
+export async function pollNewWorkspaceCommandState(
+  commandId: string,
+): Promise<ActionResult<{ status: string; payload: Record<string, unknown> }>> {
+  const supabase = await createAdminClient();
+  const { data, error } = await supabase
+    .from("agent_commands")
+    .select("status, payload, error_message")
+    .eq("id", commandId)
+    .maybeSingle();
+  if (error) return { ok: false, error: error.message };
+  if (!data) return { ok: false, error: "Command not found" };
+  return {
+    ok: true,
+    data: {
+      status: data.status,
+      payload: {
+        ...(data.payload as Record<string, unknown>),
+        error_message: data.error_message,
+      },
+    },
+  };
+}
+
+export async function saveNewWorkspaceOAuthProvider(
+  provider: string,
+): Promise<ActionResult> {
+  try {
+    const supabase = await createAdminClient();
+    const { data: gw } = await supabase
+      .from("gateways")
+      .select("id")
+      .limit(1)
+      .maybeSingle();
+
+    await supabase.from("agent_commands").insert({
+      gateway_id: gw?.id ?? null,
+      action: "auth_list",
+      payload: {},
+    });
+  } catch {
+    // Non-critical
+  }
+
+  return { ok: true };
+}
+
+// ─── (f) Create agent ───────────────────────────────────────────────────
+
+const PROVIDER_DEFAULT_MODELS: Record<string, string> = {
+  anthropic: "anthropic/claude-sonnet-4-20250514",
+  openai: "openai/gpt-4.1",
+  "openai-codex": "openai/gpt-4.1",
+  google: "google/gemini-2.5-flash",
+  "google-gemini-cli": "google/gemini-2.5-flash",
+  ollama: "ollama/llama3.3",
+  lmstudio: "lmstudio/default",
+  vllm: "vllm/default",
+  sglang: "sglang/default",
+};
+
+export async function createNewWorkspaceAgent(input: {
+  agentName: string;
+  agentSlug?: string;
+  agentEmoji: string;
+  templateBranch: string;
+  providerId?: string;
+}): Promise<ActionResult<{ agentId: string; provisionCommandId?: string }>> {
+  const slug = (input.agentSlug ?? input.agentName)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 30) || "agent";
+
+  try {
+    const supabase = await createAdminClient();
+
+    const { data: wsRow } = await supabase
+      .from("workspace")
+      .select("slug, owner_name, owner_preferred_name, owner_timezone")
+      .limit(1)
+      .maybeSingle();
+
+    const { data: gw } = await supabase
+      .from("gateways")
+      .select("id")
+      .limit(1)
+      .maybeSingle();
+
+    const meta = {
+      emoji: input.agentEmoji || undefined,
+      template_branch: input.templateBranch,
+    };
+
+    const { data: inserted, error: insertError } = await supabase
+      .from("agents")
+      .insert({
+        name: input.agentName,
+        slug,
+        gateway_id: gw?.id ?? null,
+        meta,
+      })
+      .select("id")
+      .single();
+
+    if (insertError || !inserted) {
+      return { ok: false, error: insertError?.message ?? "Failed to create agent" };
+    }
+
+    const agentId = inserted.id;
+
+    const { data: cmd, error: cmdError } = await supabase
+      .from("agent_commands")
+      .insert({
+        agent_id: agentId,
+        agent_slug: slug,
+        gateway_id: gw?.id ?? null,
+        action: "provision",
+        payload: {
+          source_template: input.templateBranch,
+          channel: "none",
+          name: input.agentName,
+          emoji: input.agentEmoji,
+          model: input.providerId ? PROVIDER_DEFAULT_MODELS[input.providerId] : undefined,
+          owner_name: wsRow?.owner_name,
+          owner_preferred_name: wsRow?.owner_preferred_name,
+          owner_timezone: wsRow?.owner_timezone,
+        },
+      })
+      .select("id")
+      .single();
+
+    if (cmdError || !cmd) {
+      return { ok: false, error: cmdError?.message ?? "Failed to enqueue provision" };
+    }
+
+    return { ok: true, data: { agentId, provisionCommandId: cmd.id } };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : "Failed to create agent",
+    };
+  }
+}
+
+export async function pollNewWorkspaceAgentProvision(
+  commandId: string,
+): Promise<"pending" | "completed" | "error"> {
+  const supabase = await createAdminClient();
+  const { data } = await supabase
+    .from("agent_commands")
+    .select("status")
+    .eq("id", commandId)
+    .maybeSingle();
+
+  if (!data) return "pending";
+  if (data.status === "done") return "completed";
+  if (data.status === "error" || data.status === "failed") return "error";
+  return "pending";
+}
+
+// ─── (g) Finalize new workspace ─────────────────────────────────────────
+
+export async function finalizeNewWorkspace(input: {
+  email: string;
+  password: string;
+  contextPresetKey?: string | null;
+  workspaceName: string;
+  workspaceSlug?: string | null;
+  ownerName?: string;
+}): Promise<ActionResult> {
+  const workspace = await getActiveWorkspaceWithSecrets();
+  if (!workspace) {
+    return { ok: false, error: "No workspace configured. Connect a database first." };
+  }
+
+  const userResult = await createAuthUser({
+    url: workspace.url,
+    serviceRoleKey: workspace.serviceRoleKey,
+    email: input.email,
+    password: input.password,
+  });
+
+  if (!userResult.ok && !userResult.error?.includes("already exists")) {
+    return { ok: false, error: userResult.error ?? "Failed to create account" };
+  }
+
+  const supabase = await createAdminClient();
+  const result = await runCompleteSetup(supabase, {
+    workspaceName: input.workspaceName,
+    workspaceSlug: input.workspaceSlug,
+    ownerName: input.ownerName,
+    contextPresetKey: input.contextPresetKey,
+  });
+
+  if (!result.ok) {
+    return { ok: false, error: result.error };
+  }
+
+  return { ok: true };
 }

--- a/apps/ui/src/app/new-workspace/actions.ts
+++ b/apps/ui/src/app/new-workspace/actions.ts
@@ -20,6 +20,7 @@ import { mintGatewayToken } from "@/lib/gateways/mint-token";
 import { buildGatewayOneLiner } from "@/lib/gateways/one-liner";
 import { dockerAvailable, startLocalGateway, localGatewayStatus } from "@/lib/gateways/local-compose";
 import { runCompleteSetup } from "@/lib/setup/run-complete-setup";
+import { parseSupabaseUrl } from "@/lib/workspaces/parse-url";
 
 interface ActionResult<T = undefined> {
   ok: boolean;
@@ -93,6 +94,87 @@ export async function confirmNewWorkspaceSchema(input: {
     return { ok: false, error: "Schema not found. Please run the SQL first, then try again." };
   }
   return { ok: true };
+}
+
+// ─── One-click migration for new workspaces ────────────────────────────
+
+export interface OneClickMigrationResult extends ActionResult {
+  applied?: number;
+  skipped?: number;
+}
+
+const oneClickSchema = z.object({
+  projectRef: z.string().min(1),
+  region: z.string().min(1),
+  dbPassword: z.string().min(1),
+});
+
+export async function runNewWorkspaceOneClickMigration(
+  input: z.infer<typeof oneClickSchema>,
+): Promise<OneClickMigrationResult> {
+  const parsed = oneClickSchema.safeParse(input);
+  if (!parsed.success) {
+    const missing = parsed.error.issues.map((i) => i.path[0]).filter(Boolean);
+    return { ok: false, error: `Missing required fields: ${missing.join(", ") || "region, password, project ref"}.` };
+  }
+
+  const { projectRef, region, dbPassword } = parsed.data;
+  const encodedPassword = encodeURIComponent(dbPassword);
+  const { runMigrations } = await import("@/lib/workspaces/run-migrations");
+
+  const poolerPrefixes = ["aws-0", "aws-1", "aws-2"];
+
+  for (const prefix of poolerPrefixes) {
+    const connectionString =
+      `postgresql://postgres.${projectRef}:${encodedPassword}@${prefix}-${region}.pooler.supabase.com:5432/postgres`;
+    try {
+      const result = await runMigrations({
+        connectionString,
+        onProgress: () => {},
+      });
+
+      if (result.errors.length > 0) {
+        const first = result.errors[0];
+        return {
+          ok: false,
+          error: `Migration failed on ${first.name}: ${first.error}`,
+          applied: result.applied.length,
+          skipped: result.skipped.length,
+        };
+      }
+
+      return {
+        ok: true,
+        applied: result.applied.length,
+        skipped: result.skipped.length,
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes("password authentication failed")) {
+        return {
+          ok: false,
+          error: "Incorrect database password.",
+          hint: "This is the password you set when creating the Supabase project, not your Supabase account password.",
+        };
+      }
+      if (msg.includes("Tenant") || msg.includes("ENOTFOUND")) {
+        continue;
+      }
+      return { ok: false, error: msg };
+    }
+  }
+
+  return {
+    ok: false,
+    error: "Could not connect to the database.",
+    hint: "Check that the region matches where you created your Supabase project, and that the project isn't paused.",
+  };
+}
+
+export async function extractProjectRefFromUrl(supabaseUrl: string): Promise<string | null> {
+  const r = parseSupabaseUrl(supabaseUrl);
+  if (!r.ok || !r.ref) return null;
+  return r.ref;
 }
 
 export async function createOssWorkspace(input: {

--- a/apps/ui/src/app/onboarding/actions.ts
+++ b/apps/ui/src/app/onboarding/actions.ts
@@ -879,13 +879,7 @@ export async function saveWorkspaceStep(
 // ─── Finalize: call complete_setup RPC + mark onboarding done ───────────
 
 import { createAdminClient } from "@/lib/supabase/admin";
-import {
-  PIPELINE_TEMPLATES,
-  FIELD_TEMPLATES,
-  DEFAULT_STREAMS,
-  DEFAULT_CONTEXT_PRESET,
-  findPreset,
-} from "@/lib/setup/templates";
+import { runCompleteSetup } from "@/lib/setup/run-complete-setup";
 
 export async function finalizeOnboarding(): Promise<ActionResult> {
   const state = await getOnboardingState();
@@ -898,175 +892,20 @@ export async function finalizeOnboarding(): Promise<ActionResult> {
     (data.workspaceName as string | undefined) ??
     (data.ownerName as string | undefined) ??
     "Workspace";
-  const workspaceSlug = (data.workspaceSlug as string | null | undefined) ?? null;
-  const workspaceDescription =
-    (data.workspaceDescription as string | undefined) ?? "";
-  const ownerName = (data.ownerName as string | undefined) ?? "";
-  const preferredName = (data.preferredName as string | undefined) ?? ownerName;
-  const timezone = (data.timezone as string | undefined) ?? "";
 
-  // Resolve the context preset — chosen on the "what will you use HQ for?"
-  // screen. Drives pipeline, fields, and streams in one shot.
-  const presetKey = (data.contextPresetKey as string | undefined) ?? null;
-  const preset = presetKey ? findPreset(presetKey) : DEFAULT_CONTEXT_PRESET;
-
-  const pipelineKey = preset.pipelineKey;
-  const fieldKey = preset.fieldKey;
-  const streamNames = preset.streamNames;
-
-  const pipelineTemplate = PIPELINE_TEMPLATES.find((t) => t.key === pipelineKey);
-  const fieldTemplate = FIELD_TEMPLATES.find((t) => t.key === fieldKey);
-  if (!pipelineTemplate || !fieldTemplate) {
-    return { ok: false, error: "Pipeline or field template not found" };
-  }
-
-  const enabledStreams = DEFAULT_STREAMS.filter((s) => streamNames.includes(s.name));
-  const defaultNames = new Set(DEFAULT_STREAMS.map((s) => s.name));
-  const customStreams = streamNames
-    .filter((name) => !defaultNames.has(name))
-    .map((name, i) => ({
-      name,
-      description: null,
-      type: "custom" as const,
-      color: "#6b7280",
-      icon: null,
-      sort_order: enabledStreams.length + i,
-    }));
-  const allStreams = [...enabledStreams, ...customStreams];
-
-  const stagesJson = pipelineTemplate.stages.map((s) => ({
-    stage_key: s.stage_key,
-    label: s.label,
-    color: s.color,
-    sort_order: s.sort_order,
-    is_terminal: s.is_terminal,
-    is_default: s.is_default,
-  }));
-
-  const fieldsJson = fieldTemplate.fields.map((f) => ({
-    field_key: f.field_key,
-    field_type: f.field_type,
-    label: f.label,
-    field_group: f.field_group,
-    sort_order: f.sort_order,
-    required: f.required,
-    options: f.options,
-    description: f.description,
-  }));
-
-  const streamsJson = allStreams.map((s) => ({
-    name: s.name,
-    description: s.description,
-    type: s.type,
-    color: s.color,
-    icon: s.icon,
-    sort_order: s.sort_order,
-  }));
-
-  // Use the admin client — complete_setup needs service_role because
-  // it writes to workspace, pipeline_stages, field_definitions, streams.
   const supabase = await createAdminClient();
-  const { error } = await supabase.rpc("complete_setup", {
-    p_name: workspaceName || "HQ",
-    p_slug: workspaceSlug,
-    p_description: workspaceDescription,
-    p_owner_name: ownerName,
-    p_preferred_name: preferredName,
-    p_timezone: timezone,
-    p_stages: stagesJson,
-    p_fields: fieldsJson,
-    p_streams: streamsJson,
-    p_tenant_id: "00000000-0000-0000-0000-000000000000",
+  const result = await runCompleteSetup(supabase, {
+    workspaceName,
+    workspaceSlug: (data.workspaceSlug as string | null | undefined) ?? null,
+    workspaceDescription: (data.workspaceDescription as string | undefined) ?? "",
+    ownerName: (data.ownerName as string | undefined) ?? "",
+    preferredName: (data.preferredName as string | undefined) ?? (data.ownerName as string | undefined) ?? "",
+    timezone: (data.timezone as string | undefined) ?? "",
+    contextPresetKey: (data.contextPresetKey as string | undefined) ?? null,
   });
-  if (error) return { ok: false, error: error.message };
-
-  // Set workspace modules based on the preset
-  const modules = preset.modules ?? { crm: true };
-  await supabase
-    .from("workspace")
-    .update({
-      settings: { modules },
-    })
-    .eq("tenant_id", "00000000-0000-0000-0000-000000000000");
-
-  // Install collection templates specified by the preset
-  if (preset.collectionTemplateSlugs?.length) {
-    for (const slug of preset.collectionTemplateSlugs) {
-      const { data: tpl } = await supabase
-        .from("collection_templates")
-        .select("definition")
-        .eq("slug", slug)
-        .maybeSingle();
-      if (!tpl?.definition) continue;
-
-      const def = tpl.definition as {
-        name?: string;
-        description?: string;
-        icon?: string;
-        color?: string;
-        fields?: Array<Record<string, unknown>>;
-        views?: Array<Record<string, unknown>>;
-      };
-
-      const { data: existing } = await supabase
-        .from("collection_definitions")
-        .select("id")
-        .eq("slug", slug)
-        .eq("tenant_id", "00000000-0000-0000-0000-000000000000")
-        .maybeSingle();
-      if (existing) continue;
-
-      const { data: created } = await supabase
-        .from("collection_definitions")
-        .insert({
-          name: def.name ?? slug,
-          slug,
-          description: def.description ?? null,
-          icon: def.icon ?? null,
-          color: def.color ?? "#6b7280",
-          tenant_id: "00000000-0000-0000-0000-000000000000",
-        })
-        .select("id")
-        .single();
-      if (!created) continue;
-
-      if (def.fields?.length) {
-        await supabase.from("collection_fields").insert(
-          def.fields.map((f, i) => ({
-            collection_id: created.id,
-            field_key: f.field_key,
-            field_type: f.field_type,
-            label: f.label,
-            sort_order: f.sort_order ?? i,
-            required: f.required ?? false,
-            options: f.options ?? null,
-            is_title_field: f.is_title_field ?? false,
-            tenant_id: "00000000-0000-0000-0000-000000000000",
-          })),
-        );
-      }
-
-      if (def.views?.length) {
-        await supabase.from("collection_views").insert(
-          def.views.map((v, i) => ({
-            collection_id: created.id,
-            name: v.name,
-            view_type: v.view_type,
-            config: v.config ?? {},
-            is_default: v.is_default ?? i === 0,
-            sort_order: v.sort_order ?? i,
-            tenant_id: "00000000-0000-0000-0000-000000000000",
-          })),
-        );
-      }
-    }
-  }
+  if (!result.ok) return { ok: false, error: result.error };
 
   await patchOnboardingState({ step: "done", complete: true });
-  // Only revalidate dashboard — the client wizard handles the transition
-  // from /onboarding (celebration screen → navigate). Revalidating
-  // /onboarding here causes a server redirect to /dashboard before the
-  // client-side sign-in completes, bouncing users to /login.
   revalidatePath("/dashboard");
   return { ok: true };
 }

--- a/apps/ui/src/components/connections/connections-settings.tsx
+++ b/apps/ui/src/components/connections/connections-settings.tsx
@@ -164,10 +164,17 @@ export function ConnectionsSettings({
       return;
     }
     if (w.data.status === "failed") {
-      toast.error(w.data.error_message ?? "Remove failed");
-      return;
+      const errMsg = (w.data.error_message ?? "").toLowerCase();
+      const alreadyGone = errMsg.includes("not found") || errMsg.includes("no connection") || errMsg.includes("no such");
+      if (alreadyGone) {
+        toast.success("Connection was already removed from the gateway");
+      } else {
+        toast.error(w.data.error_message ?? "Remove failed");
+        return;
+      }
+    } else {
+      toast.success("Connection removed");
     }
-    toast.success("Connection removed");
     setRemoving(null);
     await refresh();
   }, [refresh]);

--- a/apps/ui/src/components/dashboard-shell.tsx
+++ b/apps/ui/src/components/dashboard-shell.tsx
@@ -325,7 +325,7 @@ function SidebarInner({
 
   return (
     <>
-      {/* Workspace switcher (renders as a plain label when ≤1 workspace) */}
+      {/* Workspace switcher */}
       <WorkspaceSwitcher
         activeWorkspaceId={activeWorkspaceId}
         workspaces={workspaces}

--- a/apps/ui/src/components/onboarding/wizard/onboarding-wizard.tsx
+++ b/apps/ui/src/components/onboarding/wizard/onboarding-wizard.tsx
@@ -17,6 +17,7 @@ import { StepLaunch } from "./step-launch";
 import { StepPayment } from "./step-payment";
 import { StepProvisioning } from "./step-provisioning";
 import { StepCelebration } from "./step-celebration";
+import { AGENT_ROSTER, INTENT_TO_AGENT_KEY, type AgentTemplate } from "@/lib/agents/roster";
 import { FIRST_TASK_SUGGESTIONS } from "@/lib/onboarding/first-task-suggestions";
 import { completeItem } from "@/lib/onboarding/progress";
 import {
@@ -39,133 +40,7 @@ import {
 import { createHostedCheckout, getHostedEmail, verifyAutoLogin, sendFreshLoginLink } from "./hosted-actions";
 import { trackEvent, identifyUser } from "@/lib/analytics";
 
-interface AgentCapability {
-  label: string;
-  detail: string;
-}
-
-export interface AgentTemplate {
-  key: string;
-  branch: string;
-  name: string;
-  emoji: string;
-  role: string;
-  description: string;
-  capabilities: AgentCapability[];
-}
-
-const AGENT_ROSTER: AgentTemplate[] = [
-  {
-    key: "scout", branch: "template/crm-researcher", name: "Scout", emoji: "🕵️", role: "Sales & Outreach",
-    description: "Your dedicated sales partner — researches targets, crafts outreach, and keeps your pipeline moving.",
-    capabilities: [
-      { label: "Prospect research", detail: "Deep-dives into companies, finds decision-makers, and builds target profiles" },
-      { label: "Outreach drafting", detail: "Writes personalized emails and messages tailored to each prospect" },
-      { label: "Pipeline tracking", detail: "Keeps your deals organized and flags follow-ups before they slip" },
-      { label: "Meeting prep", detail: "Summarizes notes, tracks next steps, and preps you before every call" },
-    ],
-  },
-  {
-    key: "ghost", branch: "template/ghostwriter", name: "Ghost", emoji: "👩‍💻", role: "Content Writer",
-    description: "Your writing partner — drafts in your voice, researches topics, and keeps your content calendar full.",
-    capabilities: [
-      { label: "Content drafting", detail: "Writes newsletters, blog posts, and social threads in your voice" },
-      { label: "Topic research", detail: "Finds angles, pulls sources, and builds outlines before you write" },
-      { label: "Editing & refinement", detail: "Tightens drafts, adjusts tone, and incorporates your feedback" },
-      { label: "Calendar planning", detail: "Plans your publishing schedule and tracks what's due next" },
-    ],
-  },
-  {
-    key: "chief", branch: "template/chief-of-staff", name: "Chief", emoji: "🦸", role: "Operations",
-    description: "Your operations lead — coordinates work, tracks clients, and keeps everything on schedule.",
-    capabilities: [
-      { label: "Task management", detail: "Breaks down projects, assigns priorities, and tracks progress" },
-      { label: "Client tracking", detail: "Keeps accounts organized with status, notes, and next actions" },
-      { label: "Blocker alerts", detail: "Surfaces overdue items and bottlenecks before they become problems" },
-      { label: "Status updates", detail: "Prepares summaries and reports so you always know where things stand" },
-    ],
-  },
-  {
-    key: "researcher", branch: "template/assistant", name: "Researcher", emoji: "🧑‍🔬", role: "Research & Analysis",
-    description: "Your research analyst — digs deep into topics, synthesizes findings, and keeps your knowledge organized.",
-    capabilities: [
-      { label: "Deep research", detail: "Investigates markets, companies, and trends with structured analysis" },
-      { label: "Brief creation", detail: "Synthesizes findings into clear, actionable summaries" },
-      { label: "Monitoring", detail: "Tracks topics over time and surfaces new developments" },
-      { label: "Knowledge organization", detail: "Files research into your knowledge base so nothing gets lost" },
-    ],
-  },
-  {
-    key: "assistant", branch: "template/assistant", name: "Assistant", emoji: "🧑‍💼", role: "General Assistant",
-    description: "Your right hand — manages tasks, tracks what matters, and handles the day-to-day so you can focus.",
-    capabilities: [
-      { label: "Task management", detail: "Organizes your to-dos, sets priorities, and tracks deadlines" },
-      { label: "Research & writing", detail: "Looks into topics and drafts docs, messages, and quick write-ups" },
-      { label: "Project tracking", detail: "Monitors progress across workstreams and flags what needs attention" },
-      { label: "Workspace upkeep", detail: "Keeps everything organized, up to date, and easy to find" },
-    ],
-  },
-  {
-    key: "cofounder", branch: "template/cofounder", name: "Co-Founder", emoji: "🚀", role: "Strategy & Execution",
-    description: "Your strategic operator — helps drive execution, shape direction, and keep the business moving.",
-    capabilities: [
-      { label: "Strategic planning", detail: "Breaks down big goals into actionable next steps" },
-      { label: "Decision support", detail: "Frames trade-offs and surfaces the data you need to decide" },
-      { label: "Execution tracking", detail: "Keeps initiatives on track and flags when things stall" },
-      { label: "Market awareness", detail: "Monitors competitors, trends, and opportunities" },
-    ],
-  },
-  {
-    key: "cmo", branch: "template/cmo", name: "CMO", emoji: "📡", role: "Marketing Strategy",
-    description: "Your marketing strategist — designs messaging, plans campaigns, and builds your funnel.",
-    capabilities: [
-      { label: "Campaign strategy", detail: "Plans multi-channel campaigns aligned to your goals" },
-      { label: "Messaging & positioning", detail: "Crafts clear value props that resonate with your audience" },
-      { label: "Funnel design", detail: "Maps the journey from awareness to conversion" },
-      { label: "Performance analysis", detail: "Tracks what's working and recommends where to double down" },
-    ],
-  },
-  {
-    key: "analytics", branch: "template/analytics", name: "Analytics", emoji: "📊", role: "Data & Insights",
-    description: "Your performance analyst — turns activity and outcomes into clear metrics and action items.",
-    capabilities: [
-      { label: "Metric tracking", detail: "Monitors KPIs and highlights meaningful changes" },
-      { label: "Trend analysis", detail: "Spots patterns in your data and explains what's driving them" },
-      { label: "Reporting", detail: "Builds clear dashboards and summaries for stakeholders" },
-      { label: "Recommendations", detail: "Translates insights into specific next steps" },
-    ],
-  },
-  {
-    key: "designer", branch: "template/designer", name: "Designer", emoji: "🎨", role: "Visual Design",
-    description: "Your visual creator — turns ideas into clear, engaging graphics and polished content.",
-    capabilities: [
-      { label: "Graphic creation", detail: "Designs social graphics, presentations, and brand assets" },
-      { label: "Content formatting", detail: "Polishes docs and decks for a professional look" },
-      { label: "Brand consistency", detail: "Keeps your visual identity cohesive across everything" },
-      { label: "Creative concepts", detail: "Explores visual directions and translates ideas into layouts" },
-    ],
-  },
-  {
-    key: "market-researcher", branch: "template/market-researcher", name: "Market Intel", emoji: "🔮", role: "Market Intelligence",
-    description: "Your external intelligence agent — scans markets, spots patterns, and surfaces meaningful signals.",
-    capabilities: [
-      { label: "Competitive analysis", detail: "Tracks competitors, their moves, and positioning shifts" },
-      { label: "Market scanning", detail: "Monitors industry trends and emerging opportunities" },
-      { label: "Signal detection", detail: "Surfaces news, funding rounds, and key market events" },
-      { label: "Intelligence briefs", detail: "Delivers structured summaries you can act on quickly" },
-    ],
-  },
-];
-
-const INTENT_TO_AGENT_KEY: Record<string, string> = {
-  reach: "scout",
-  publish: "ghost",
-  run: "chief",
-  hire: "scout",
-  research: "researcher",
-  organized: "assistant",
-  explore: "assistant",
-};
+export type { AgentTemplate };
 
 const STEP_LAYOUT: Record<string, "narrow" | "wide"> = {
   welcome: "narrow",

--- a/apps/ui/src/components/onboarding/wizard/step-agent.tsx
+++ b/apps/ui/src/components/onboarding/wizard/step-agent.tsx
@@ -20,7 +20,7 @@ import {
 import { cn } from "@/lib/utils";
 import { AGENT_EMOJIS, AGENT_EMOJI_LABELS } from "@/lib/agents/emoji-grid";
 import { StaggeredEntrance } from "./staggered-entrance";
-import type { AgentTemplate } from "./onboarding-wizard";
+import type { AgentTemplate } from "@/lib/agents/roster";
 
 /* ── Constants ─────────────────────────────────────────────────────── */
 

--- a/apps/ui/src/components/onboarding/wizard/step-provider.tsx
+++ b/apps/ui/src/components/onboarding/wizard/step-provider.tsx
@@ -41,6 +41,13 @@ const AUTH_SHAPE_LABELS: Record<string, string> = {
   local_url: "Local",
 };
 
+export interface StepProviderActions {
+  startOAuthFlow: typeof startOAuthFlow;
+  submitOAuthPaste: typeof submitOAuthPaste;
+  pollCommandState: typeof pollCommandState;
+  saveOAuthProvider: typeof saveOAuthProvider;
+}
+
 export interface StepProviderProps {
   onSubmit: (provider: string, apiKey: string) => void;
   pending: boolean;
@@ -49,6 +56,7 @@ export interface StepProviderProps {
   validationError?: string | null;
   isHosted?: boolean;
   collectOnly?: boolean;
+  actions?: StepProviderActions;
 }
 
 type OAuthPhase =
@@ -71,7 +79,9 @@ export function StepProvider({
   validationError,
   isHosted,
   collectOnly,
+  actions,
 }: StepProviderProps) {
+  const oauthActions = actions ?? { startOAuthFlow, submitOAuthPaste, pollCommandState, saveOAuthProvider };
   const [selected, setSelected] = useState<string | null>(null);
   const [apiKey, setApiKey] = useState("");
   const [showKey, setShowKey] = useState(false);
@@ -127,7 +137,7 @@ export function StepProvider({
     setOauthPhase({ kind: "starting", provider: entry, mode });
     setOauthError(null);
 
-    const r = await startOAuthFlow(entry.id, mode);
+    const r = await oauthActions.startOAuthFlow(entry.id, mode);
     if (!r.ok || !r.data) {
       setOauthError(r.error ?? "Failed to start sign-in");
       setOauthPhase({ kind: "idle" });
@@ -145,7 +155,7 @@ export function StepProvider({
 
     if (pollRef.current) clearInterval(pollRef.current);
     pollRef.current = setInterval(async () => {
-      const poll = await pollCommandState(commandId);
+      const poll = await oauthActions.pollCommandState(commandId);
       if (!poll.ok || !poll.data) return;
 
       const cs = (poll.data.payload?.connection_state ?? null) as ConnectionCommandState | null;
@@ -159,7 +169,7 @@ export function StepProvider({
       if (poll.data.status === "done") {
         if (pollRef.current) clearInterval(pollRef.current);
         setOauthPhase({ kind: "done", provider: entry });
-        await saveOAuthProvider(entry.id);
+        await oauthActions.saveOAuthProvider(entry.id);
       } else if (poll.data.status === "failed") {
         if (pollRef.current) clearInterval(pollRef.current);
         setOauthError(
@@ -168,12 +178,13 @@ export function StepProvider({
         setOauthPhase({ kind: "idle" });
       }
     }, 1500);
-  }, []);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [oauthActions]);
 
   const handlePaste = useCallback(async (value: string) => {
     if (oauthPhase.kind !== "interactive" || !value) return;
     setSubmittingPaste(true);
-    const r = await submitOAuthPaste(oauthPhase.commandId, value);
+    const r = await oauthActions.submitOAuthPaste(oauthPhase.commandId, value);
     setSubmittingPaste(false);
     if (!r.ok) {
       setOauthError(r.error ?? "Failed to submit code");

--- a/apps/ui/src/components/tasks/agent-status-chip.tsx
+++ b/apps/ui/src/components/tasks/agent-status-chip.tsx
@@ -1,20 +1,30 @@
 "use client";
 
 import type { Task } from "@/lib/tasks/types";
-import { Bot, CheckCircle2 } from "lucide-react";
+import { Bot, CheckCircle2, AlertTriangle } from "lucide-react";
 import { formatDistanceToNow } from "date-fns";
 import { cn } from "@/lib/utils";
 
 interface AgentStatusChipProps {
   task: Task;
   compact?: boolean;
+  inboxFailed?: boolean;
 }
 
-export function AgentStatusChip({ task, compact }: AgentStatusChipProps) {
+export function AgentStatusChip({ task, compact, inboxFailed }: AgentStatusChipProps) {
   if (task.assignee_type !== "agent" || !task.assignee_agent) return null;
 
   const name = task.assignee_agent.name;
   const emoji = task.assignee_agent.meta?.emoji as string | undefined;
+
+  if (inboxFailed) {
+    return (
+      <span className="inline-flex items-center gap-1 text-[11px] text-[var(--status-error)]">
+        <AlertTriangle className="h-3 w-3" />
+        {!compact && <span className="truncate max-w-[120px]">{name} failed</span>}
+      </span>
+    );
+  }
 
   if (task.status === "done" && task.completed_at) {
     return (

--- a/apps/ui/src/components/tasks/task-form.tsx
+++ b/apps/ui/src/components/tasks/task-form.tsx
@@ -110,6 +110,7 @@ export function TaskForm({ streams, editingTask, onSave, onCancel, onArchive, de
   const [modelOverride, setModelOverrideRaw] = useState<string | null>(editingTask?.model_override ?? null);
   const [thinkingOverride, setThinkingOverrideRaw] = useState<string | null>(editingTask?.thinking_override ?? null);
   const [scopeDialogOpen, setScopeDialogOpen] = useState(false);
+  const [inboxFailed, setInboxFailed] = useState(false);
   const { actions: seriesActions } = useTaskSeries();
   const editingSeriesId = editingTask?.series_id ?? null;
 
@@ -296,6 +297,26 @@ export function TaskForm({ streams, editingTask, onSave, onCancel, onArchive, de
       if (data) setAgents(data as Agent[]);
     });
   }, [supabase]);
+
+  // Check for failed inbox items when the task is agent-assigned
+  const hasAgentAssignee = assignee !== "none" && assignee !== "me";
+  useEffect(() => {
+    if (!savedTaskId || !hasAgentAssignee) {
+      setInboxFailed(false);
+      return;
+    }
+    supabase
+      .from("agent_inbox_items")
+      .select("id, status, attempt_count")
+      .eq("task_id", savedTaskId)
+      .eq("status", "failed")
+      .gte("attempt_count", 3)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .then(({ data }) => {
+        setInboxFailed(!!data?.length);
+      });
+  }, [savedTaskId, hasAgentAssignee, supabase]);
 
   // Auto-resize title
   useEffect(() => {
@@ -507,6 +528,15 @@ export function TaskForm({ streams, editingTask, onSave, onCancel, onArchive, de
         <ResponsiveDialogDescription className="sr-only">
           Create or edit a task with title, description, status, priority, stream, assignee, and due date.
         </ResponsiveDialogDescription>
+
+        {/* Agent inbox failure banner */}
+        {inboxFailed && assigneeAgent && (
+          <div className="flex items-center gap-2 bg-destructive/10 border-b border-destructive/20 px-4 sm:px-5 py-2 text-xs text-destructive shrink-0">
+            <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+            <span>{assigneeAgent.name} failed to process this task after multiple attempts.</span>
+            {/* TODO: add retry action that resets the inbox item and re-queues */}
+          </div>
+        )}
 
         {/* Missed task banner */}
         {isMissed && editingTask?.due_date && (

--- a/apps/ui/src/components/workspaces/new-workspace-wizard.tsx
+++ b/apps/ui/src/components/workspaces/new-workspace-wizard.tsx
@@ -488,13 +488,13 @@ export function NewWorkspaceWizard({ isHosted, email: initialEmail }: Props) {
 
   return (
     <div className="flex w-full flex-col items-center pt-8">
-      <div className="mb-8 w-full max-w-lg">
-        <WizardProgress steps={progressSteps} currentStep={step} />
-      </div>
-
       <div className={cn(
-        layout === "narrow" ? "w-full max-w-lg" : "w-full max-w-3xl",
+        "w-full transition-all duration-300",
+        layout === "narrow" ? "max-w-lg" : "max-w-3xl",
       )}>
+        <div className="mb-8">
+          <WizardProgress steps={progressSteps} currentStep={step} />
+        </div>
         {!isFirst && step !== "provisioning" && step !== "done" && (
           <button
             type="button"

--- a/apps/ui/src/components/workspaces/new-workspace-wizard.tsx
+++ b/apps/ui/src/components/workspaces/new-workspace-wizard.tsx
@@ -1,30 +1,60 @@
 "use client";
 
-import { useCallback, useEffect, useState, useTransition } from "react";
+import { useCallback, useEffect, useRef, useState, useTransition } from "react";
 import { useSearchParams } from "next/navigation";
-import { ArrowLeft, ArrowRight, Check, Loader2, AlertCircle, CreditCard, Eye, EyeOff, Copy, CheckCheck, ExternalLink } from "lucide-react";
+import {
+  ArrowLeft,
+  ArrowRight,
+  Check,
+  Loader2,
+  AlertCircle,
+  CreditCard,
+  Eye,
+  EyeOff,
+  Copy,
+  CheckCheck,
+  ExternalLink,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import { StaggeredEntrance } from "@/components/onboarding/wizard/staggered-entrance";
 import { WizardProgress } from "@/components/onboarding/wizard/wizard-progress";
 import { StepProvisioning } from "@/components/onboarding/wizard/step-provisioning";
+import { StepIntent } from "@/components/onboarding/wizard/step-intent";
+import { StepProvider, type StepProviderActions } from "@/components/onboarding/wizard/step-provider";
+import { StepAgent } from "@/components/onboarding/wizard/step-agent";
+import { AGENT_ROSTER, INTENT_TO_AGENT_KEY } from "@/lib/agents/roster";
 import {
   validateNewWorkspaceDb,
   confirmNewWorkspaceSchema,
-  createOssWorkspace,
   createHostedWorkspaceCheckout,
+  registerNewWorkspaceDb,
+  mintNewWorkspaceGatewayToken,
+  pollNewWorkspaceGateway,
+  startLocalNewWorkspaceGateway,
+  connectNewWorkspaceProvider,
+  startNewWorkspaceOAuth,
+  submitNewWorkspaceOAuthPaste,
+  pollNewWorkspaceCommandState,
+  saveNewWorkspaceOAuthProvider,
+  createNewWorkspaceAgent,
+  pollNewWorkspaceAgentProvision,
+  finalizeNewWorkspace,
 } from "@/app/new-workspace/actions";
 import { verifyAutoLogin } from "@/components/onboarding/wizard/hosted-actions";
 
-type Step = "name" | "database" | "account" | "payment" | "provisioning" | "done";
+type Step = "name" | "intent" | "database" | "gateway" | "provider" | "agent" | "account" | "payment" | "provisioning" | "done";
 
-const OSS_STEPS: Step[] = ["name", "database", "account", "done"];
+const OSS_STEPS: Step[] = ["name", "intent", "database", "gateway", "provider", "agent", "account", "done"];
 const HOSTED_STEPS: Step[] = ["name", "payment", "provisioning", "done"];
 
 const OSS_PROGRESS = [
   { key: "name", label: "Name" },
+  { key: "intent", label: "Focus" },
   { key: "database", label: "Database" },
+  { key: "gateway", label: "Gateway" },
+  { key: "provider", label: "AI" },
+  { key: "agent", label: "Agent" },
   { key: "account", label: "Account" },
-  { key: "done", label: "Done" },
 ];
 
 const HOSTED_PROGRESS = [
@@ -34,10 +64,30 @@ const HOSTED_PROGRESS = [
   { key: "done", label: "Done" },
 ];
 
+const STEP_LAYOUT: Record<string, "narrow" | "wide"> = {
+  name: "narrow",
+  intent: "narrow",
+  database: "narrow",
+  gateway: "wide",
+  provider: "wide",
+  agent: "wide",
+  account: "narrow",
+  payment: "narrow",
+  provisioning: "narrow",
+  done: "narrow",
+};
+
 interface Props {
   isHosted: boolean;
   email?: string;
 }
+
+const newWorkspaceOAuthActions: StepProviderActions = {
+  startOAuthFlow: startNewWorkspaceOAuth,
+  submitOAuthPaste: submitNewWorkspaceOAuthPaste,
+  pollCommandState: pollNewWorkspaceCommandState,
+  saveOAuthProvider: saveNewWorkspaceOAuthProvider,
+};
 
 export function NewWorkspaceWizard({ isHosted, email: initialEmail }: Props) {
   const searchParams = useSearchParams();
@@ -51,13 +101,35 @@ export function NewWorkspaceWizard({ isHosted, email: initialEmail }: Props) {
 
   // Wizard data
   const [label, setLabel] = useState("");
-  const [emoji, setEmoji] = useState("🏠");
+  const [emoji, setEmoji] = useState("\u{1F3E0}");
+  const [intentKey, setIntentKey] = useState<string | null>(null);
   const [dbUrl, setDbUrl] = useState("");
   const [anonKey, setAnonKey] = useState("");
   const [serviceRoleKey, setServiceRoleKey] = useState("");
+  const [_workspaceId, setWorkspaceId] = useState<string | null>(null);
   const [accountEmail, setAccountEmail] = useState(initialEmail ?? "");
   const [password, setPassword] = useState("");
   const [hostedWorkspaceId, setHostedWorkspaceId] = useState<string | null>(null);
+
+  // Gateway state
+  const [gatewayPlacement, setGatewayPlacement] = useState<"local" | "remote" | null>(null);
+  const [gatewayStatus, setGatewayStatus] = useState<"idle" | "starting" | "polling" | "connected" | "error">("idle");
+  const [gatewayError, setGatewayError] = useState<string | null>(null);
+  const [gatewayOneLiner, setGatewayOneLiner] = useState<string | null>(null);
+  const [_gatewayTokenId, setGatewayTokenId] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Provider state
+  const [providerId, setProviderId] = useState<string | null>(null);
+  const [validating, setValidating] = useState(false);
+  const [validated, setValidated] = useState(false);
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  // Agent state
+  const [provisionStatus, setProvisionStatus] = useState<"idle" | "provisioning" | "ready" | "error">("idle");
+  const [provisionError, setProvisionError] = useState<string | null>(null);
+  const [agentName, setAgentName] = useState<string | null>(null);
+  const [agentEmoji, setAgentEmoji] = useState<string | null>(null);
 
   // DB validation state
   const [dbStatus, setDbStatus] = useState<"idle" | "validating" | "schema-needed" | "connected" | "error">("idle");
@@ -65,6 +137,20 @@ export function NewWorkspaceWizard({ isHosted, email: initialEmail }: Props) {
   const [schemaSql, setSchemaSql] = useState<string | null>(null);
   const [sqlEditorUrl, setSqlEditorUrl] = useState<string | null>(null);
   const [schemaConfirming, setSchemaConfirming] = useState(false);
+
+  useEffect(() => {
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (step !== "provider") {
+      setValidating(false);
+      setValidated(false);
+      setValidationError(null);
+    }
+  }, [step]);
 
   const advance = useCallback(() => {
     const idx = steps.indexOf(step);
@@ -110,6 +196,14 @@ export function NewWorkspaceWizard({ isHosted, email: initialEmail }: Props) {
     setStep(steps[1]);
   }, [label, steps]);
 
+  // ─── Intent step ───
+  const handleIntent = useCallback((key: string) => {
+    setIntentKey(key);
+    setDirection("forward");
+    setError(null);
+    setStep("database");
+  }, []);
+
   // ─── Database step (OSS) ───
   const handleValidateDb = useCallback(() => {
     setDbStatus("validating");
@@ -152,17 +246,160 @@ export function NewWorkspaceWizard({ isHosted, email: initialEmail }: Props) {
     });
   }, [dbUrl, anonKey, serviceRoleKey, startTransition]);
 
-  // ─── Account step (OSS) ───
-  const handleCreateWorkspace = useCallback(() => {
+  const handleDbContinue = useCallback(() => {
     startTransition(async () => {
-      const r = await createOssWorkspace({
+      const r = await registerNewWorkspaceDb({
         label: label.trim(),
         emoji,
         url: dbUrl.trim(),
         anonKey: anonKey.trim(),
         serviceRoleKey: serviceRoleKey.trim(),
+      });
+      if (!r.ok) {
+        setError(r.error ?? "Failed to register workspace");
+        return;
+      }
+      setWorkspaceId(r.data?.workspaceId ?? null);
+      advance();
+    });
+  }, [label, emoji, dbUrl, anonKey, serviceRoleKey, startTransition, advance]);
+
+  // ─── Gateway step ───
+  const handleChooseGateway = useCallback((placement: "local" | "remote") => {
+    setGatewayPlacement(placement);
+    setGatewayStatus("starting");
+    setGatewayError(null);
+    setGatewayOneLiner(null);
+
+    startTransition(async () => {
+      if (placement === "local") {
+        const r = await startLocalNewWorkspaceGateway();
+        if (!r.ok) {
+          setGatewayStatus("error");
+          setGatewayError(r.error ?? "Failed to start gateway");
+        } else {
+          setGatewayStatus("polling");
+        }
+      } else {
+        const r = await mintNewWorkspaceGatewayToken();
+        if (!r.ok || !r.data) {
+          setGatewayStatus("error");
+          setGatewayError(r.error ?? "Failed to mint token");
+          return;
+        }
+        setGatewayOneLiner(r.data.oneLiner);
+        setGatewayTokenId(r.data.tokenId);
+        setGatewayStatus("polling");
+      }
+
+      if (pollRef.current) clearInterval(pollRef.current);
+      pollRef.current = setInterval(async () => {
+        const poll = await pollNewWorkspaceGateway();
+        if (poll.ok && poll.data?.status === "ready") {
+          if (pollRef.current) clearInterval(pollRef.current);
+          setGatewayStatus("connected");
+        }
+      }, 3000);
+    });
+  }, [startTransition]);
+
+  const handleGatewaySkip = useCallback(() => {
+    if (pollRef.current) clearInterval(pollRef.current);
+    advance();
+  }, [advance]);
+
+  const handleGatewayContinue = useCallback(() => {
+    if (pollRef.current) clearInterval(pollRef.current);
+    advance();
+  }, [advance]);
+
+  // ─── Provider step ───
+  const handleProvider = useCallback((provider: string, apiKey: string) => {
+    setValidating(true);
+    setValidationError(null);
+    startTransition(async () => {
+      const r = await connectNewWorkspaceProvider(provider, apiKey);
+      setValidating(false);
+      if (r.ok) {
+        setValidated(true);
+        setProviderId(provider);
+        setTimeout(() => advance(), 600);
+      } else {
+        setValidationError(r.error ?? "Could not validate key");
+      }
+    });
+  }, [startTransition, advance]);
+
+  // ─── Agent step ───
+  const getRecommendedKey = (): string => {
+    const key = intentKey ?? "organized";
+    return INTENT_TO_AGENT_KEY[key] ?? "assistant";
+  };
+
+  const handleCreateAgent = useCallback(
+    async (agentData: { name: string; emoji: string; templateBranch: string }) => {
+      const r = await createNewWorkspaceAgent({
+        agentName: agentData.name,
+        agentEmoji: agentData.emoji,
+        templateBranch: agentData.templateBranch,
+        providerId: providerId ?? undefined,
+      });
+      if (!r.ok || !r.data) {
+        setError(r.error ?? "Failed to create agent");
+        return null;
+      }
+
+      const { agentId, provisionCommandId } = r.data;
+      setAgentName(agentData.name);
+      setAgentEmoji(agentData.emoji);
+      setProvisionStatus("provisioning");
+
+      if (provisionCommandId) {
+        const startedAt = Date.now();
+        const interval = setInterval(async () => {
+          const status = await pollNewWorkspaceAgentProvision(provisionCommandId);
+          if (status === "completed") {
+            clearInterval(interval);
+            setProvisionStatus("ready");
+          } else if (status === "error") {
+            clearInterval(interval);
+            setProvisionStatus("error");
+            setProvisionError("Agent provisioning failed");
+          } else if (Date.now() - startedAt > 120_000) {
+            clearInterval(interval);
+            setProvisionStatus("ready");
+          }
+        }, 3000);
+      }
+
+      return { agentId, provisionCommandId };
+    },
+    [providerId],
+  );
+
+  const agentDoneFired = useRef(false);
+  useEffect(() => {
+    if (step !== "agent") {
+      agentDoneFired.current = false;
+      return;
+    }
+    if (agentDoneFired.current) return;
+    if (provisionStatus === "ready" || provisionStatus === "error") {
+      agentDoneFired.current = true;
+      const timer = setTimeout(() => advance(), 800);
+      return () => clearTimeout(timer);
+    }
+  }, [step, provisionStatus, advance]);
+
+  // ─── Account step (OSS) ───
+  const handleCreateWorkspace = useCallback(() => {
+    startTransition(async () => {
+      const r = await finalizeNewWorkspace({
         email: accountEmail.trim(),
         password,
+        contextPresetKey: intentKey,
+        workspaceName: label.trim() || "My Workspace",
+        ownerName: "",
       });
       if (!r.ok) {
         setError(r.error ?? "Failed to create workspace");
@@ -180,7 +417,7 @@ export function NewWorkspaceWizard({ isHosted, email: initialEmail }: Props) {
       }
       advance();
     });
-  }, [label, emoji, dbUrl, anonKey, serviceRoleKey, accountEmail, password, startTransition, advance]);
+  }, [accountEmail, password, intentKey, label, startTransition, advance]);
 
   // ─── Payment step (Hosted) ───
   const handlePaymentCheckout = useCallback(async () => {
@@ -212,6 +449,7 @@ export function NewWorkspaceWizard({ isHosted, email: initialEmail }: Props) {
 
   const currentIndex = steps.indexOf(step);
   const isFirst = currentIndex === 0;
+  const layout = STEP_LAYOUT[step] ?? "narrow";
 
   return (
     <div className="flex w-full flex-col items-center pt-8">
@@ -219,7 +457,9 @@ export function NewWorkspaceWizard({ isHosted, email: initialEmail }: Props) {
         <WizardProgress steps={progressSteps} currentStep={step} />
       </div>
 
-      <div className="w-full max-w-lg">
+      <div className={cn(
+        layout === "narrow" ? "w-full max-w-lg" : "w-full max-w-3xl",
+      )}>
         {!isFirst && step !== "provisioning" && step !== "done" && (
           <button
             type="button"
@@ -257,6 +497,15 @@ export function NewWorkspaceWizard({ isHosted, email: initialEmail }: Props) {
             />
           )}
 
+          {step === "intent" && (
+            <StepIntent
+              ownerName=""
+              initialKey={intentKey}
+              onSubmit={handleIntent}
+              pending={pending}
+            />
+          )}
+
           {step === "database" && (
             <DatabaseStep
               dbUrl={dbUrl}
@@ -272,7 +521,44 @@ export function NewWorkspaceWizard({ isHosted, email: initialEmail }: Props) {
               schemaConfirming={schemaConfirming}
               onValidate={handleValidateDb}
               onConfirmSchema={handleConfirmSchema}
-              onContinue={advance}
+              onContinue={handleDbContinue}
+              pending={pending}
+            />
+          )}
+
+          {step === "gateway" && (
+            <GatewayStep
+              status={gatewayStatus}
+              error={gatewayError}
+              placement={gatewayPlacement}
+              oneLiner={gatewayOneLiner}
+              onChoose={handleChooseGateway}
+              onSkip={handleGatewaySkip}
+              onContinue={handleGatewayContinue}
+              pending={pending}
+            />
+          )}
+
+          {step === "provider" && (
+            <StepProvider
+              onSubmit={handleProvider}
+              pending={pending}
+              validating={validating}
+              validated={validated}
+              validationError={validationError}
+              isHosted={false}
+              collectOnly={false}
+              actions={newWorkspaceOAuthActions}
+            />
+          )}
+
+          {step === "agent" && (
+            <StepAgent
+              roster={AGENT_ROSTER}
+              recommendedKey={getRecommendedKey()}
+              onCreateAgent={handleCreateAgent}
+              provisionStatus={provisionStatus}
+              provisionError={provisionError}
               pending={pending}
             />
           )}
@@ -307,6 +593,8 @@ export function NewWorkspaceWizard({ isHosted, email: initialEmail }: Props) {
           {step === "done" && (
             <DoneStep
               workspaceName={label.trim() || "My Workspace"}
+              agentName={agentName}
+              agentEmoji={agentEmoji}
               onGoToDashboard={() => {
                 window.location.href = "/dashboard";
               }}
@@ -491,7 +779,7 @@ function DatabaseStep({
             onChange={(e) => onAnonKeyChange(e.target.value)}
             spellCheck={false}
             autoComplete="off"
-            placeholder="eyJhbGciOi…"
+            placeholder="eyJhbGciOi..."
             className="flex h-10 w-full rounded-lg border border-border/60 bg-background px-3 font-mono text-[12px] outline-none transition-colors placeholder:text-muted-foreground/50 focus:border-primary/40 focus:ring-1 focus:ring-primary/10"
           />
         </div>
@@ -507,7 +795,7 @@ function DatabaseStep({
             onChange={(e) => onServiceRoleKeyChange(e.target.value)}
             spellCheck={false}
             autoComplete="off"
-            placeholder="eyJhbGciOi…"
+            placeholder="eyJhbGciOi..."
             className="flex h-10 w-full rounded-lg border border-border/60 bg-background px-3 font-mono text-[12px] outline-none transition-colors placeholder:text-muted-foreground/50 focus:border-primary/40 focus:ring-1 focus:ring-primary/10"
           />
         </div>
@@ -540,7 +828,7 @@ function DatabaseStep({
           {schemaSql && (
             <div className="relative">
               <pre className="max-h-40 overflow-auto rounded-md bg-muted/50 p-3 text-[11px] font-mono text-muted-foreground">
-                {schemaSql.slice(0, 500)}{schemaSql.length > 500 ? "…" : ""}
+                {schemaSql.slice(0, 500)}{schemaSql.length > 500 ? "..." : ""}
               </pre>
               <button
                 type="button"
@@ -565,7 +853,7 @@ function DatabaseStep({
             {schemaConfirming ? (
               <>
                 <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                Verifying…
+                Verifying...
               </>
             ) : (
               "Verify schema"
@@ -597,7 +885,7 @@ function DatabaseStep({
             {status === "validating" ? (
               <>
                 <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                Validating…
+                Validating...
               </>
             ) : (
               <>
@@ -610,13 +898,274 @@ function DatabaseStep({
           <button
             type="button"
             onClick={onContinue}
-            className="group inline-flex items-center gap-2 rounded-full bg-foreground px-5 py-2.5 text-[13px] font-medium text-background transition-all hover:bg-foreground/90 active:scale-[0.97]"
+            disabled={pending}
+            className={cn(
+              "group inline-flex items-center gap-2 rounded-full px-5 py-2.5 text-[13px] font-medium transition-all",
+              pending
+                ? "cursor-not-allowed bg-muted text-muted-foreground/50"
+                : "bg-foreground text-background hover:bg-foreground/90 active:scale-[0.97]",
+            )}
+          >
+            {pending ? (
+              <>
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                Registering...
+              </>
+            ) : (
+              <>
+                Continue
+                <ArrowRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5" />
+              </>
+            )}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Gateway Step ─────────────────────────────────────────────────────────
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        navigator.clipboard.writeText(text);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }}
+      className="rounded p-1 text-muted-foreground/60 transition-colors hover:text-foreground"
+      aria-label="Copy"
+    >
+      {copied ? <CheckCheck className="h-3.5 w-3.5 text-status-success" /> : <Copy className="h-3.5 w-3.5" />}
+    </button>
+  );
+}
+
+function GatewayStep({
+  status,
+  error,
+  placement,
+  oneLiner,
+  onChoose,
+  onSkip,
+  onContinue,
+  pending,
+}: {
+  status: "idle" | "starting" | "polling" | "connected" | "error";
+  error: string | null;
+  placement: "local" | "remote" | null;
+  oneLiner: string | null;
+  onChoose: (placement: "local" | "remote") => void;
+  onSkip: () => void;
+  onContinue: () => void;
+  pending: boolean;
+}) {
+  const isActive = status === "polling" || status === "starting";
+  const [tick, setTick] = useState(0);
+  const startRef = useRef(0);
+
+  useEffect(() => {
+    if (!isActive) return;
+    startRef.current = tick;
+    const id = setInterval(() => setTick((t) => t + 1), 1000);
+    return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isActive]);
+
+  const elapsed = isActive ? tick - startRef.current : 0;
+
+  return (
+    <div className="space-y-8">
+      <div className="space-y-3">
+        <div className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground/70">
+          Gateway
+        </div>
+        <h1 className="text-[24px] md:text-[28px] font-semibold leading-[1.15] tracking-tight">
+          Connect your gateway
+        </h1>
+        <p className="max-w-[52ch] text-[14px] leading-relaxed text-muted-foreground">
+          The gateway is a lightweight process that runs your AI agents. It connects to your database
+          and handles everything from task execution to browser automation.
+        </p>
+      </div>
+
+      {status === "connected" ? (
+        <div className="space-y-5">
+          <div className="rounded-xl border border-status-success/20 bg-status-success/[0.04] px-4 py-3">
+            <div className="flex items-center gap-2 text-[13px] text-status-success">
+              <Check className="h-3.5 w-3.5" />
+              Gateway connected
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onContinue}
+            disabled={pending}
+            className="group inline-flex items-center gap-2 rounded-full bg-primary px-5 py-2.5 text-[13px] font-medium text-primary-foreground shadow-sm transition-all hover:brightness-110 active:scale-[0.97]"
           >
             Continue
             <ArrowRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5" />
           </button>
-        )}
-      </div>
+        </div>
+      ) : (
+        <div className="space-y-5">
+          <div role="radiogroup" aria-label="Gateway placement" className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <button
+              type="button"
+              role="radio"
+              aria-checked={placement === "local"}
+              onClick={() => status === "idle" && onChoose("local")}
+              disabled={status !== "idle"}
+              className={cn(
+                "flex flex-col gap-2.5 rounded-xl border p-4 text-left transition-all",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground/20 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+                placement === "local"
+                  ? "border-primary/50 bg-primary/[0.04] ring-1 ring-primary/10"
+                  : "border-border/60 bg-card/40 hover:border-border hover:bg-card/70",
+                status !== "idle" && placement !== "local" && "opacity-40 pointer-events-none",
+              )}
+            >
+              <div className="flex items-center gap-2.5">
+                <span className="text-[18px]">{"\u{1F4BB}"}</span>
+                <span className="text-[13px] font-medium">This machine</span>
+              </div>
+              <p className="text-[12px] leading-relaxed text-muted-foreground/70">
+                Runs via Docker on your computer. Best for trying things out and local development.
+              </p>
+              <div className="flex items-center gap-2">
+                <span className="inline-flex rounded-full bg-muted/60 px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+                  Docker required
+                </span>
+                <span className="text-[10px] text-muted-foreground/40">~2 min setup</span>
+              </div>
+            </button>
+
+            <button
+              type="button"
+              role="radio"
+              aria-checked={placement === "remote"}
+              onClick={() => status === "idle" && onChoose("remote")}
+              disabled={status !== "idle"}
+              className={cn(
+                "flex flex-col gap-2.5 rounded-xl border p-4 text-left transition-all",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground/20 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+                placement === "remote"
+                  ? "border-primary/50 bg-primary/[0.04] ring-1 ring-primary/10"
+                  : "border-border/60 bg-card/40 hover:border-border hover:bg-card/70",
+                status !== "idle" && placement !== "remote" && "opacity-40 pointer-events-none",
+              )}
+            >
+              <div className="flex items-center gap-2.5">
+                <span className="text-[18px]">{"☁️"}</span>
+                <span className="text-[13px] font-medium">Remote server</span>
+              </div>
+              <p className="text-[12px] leading-relaxed text-muted-foreground/70">
+                Deploy on any Linux server or VPS for always-on agents that run 24/7.
+              </p>
+              <div className="flex items-center gap-2">
+                <span className="inline-flex rounded-full bg-muted/60 px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+                  Any Linux server
+                </span>
+                <span className="text-[10px] text-muted-foreground/40">~5 min setup</span>
+              </div>
+            </button>
+          </div>
+
+          {oneLiner && (status === "polling" || status === "starting") && (
+            <div className="rounded-xl border border-border/40 bg-card/20 p-4 space-y-3 animate-in fade-in slide-in-from-bottom-2 duration-300">
+              <div className="space-y-1">
+                <p className="text-[12px] font-medium text-foreground">
+                  Run this on your server
+                </p>
+                <p className="text-[11px] text-muted-foreground/60">
+                  SSH into your Linux server and paste this command. It includes your
+                  Supabase credentials and a one-time registration token (expires in 15 min).
+                </p>
+              </div>
+              <div className="relative rounded-lg border border-border/40 bg-muted/30">
+                <div className="absolute right-2 top-2">
+                  <CopyButton text={oneLiner} />
+                </div>
+                <pre className="overflow-x-auto px-3 py-3 pr-10 text-[11px] leading-relaxed font-mono text-foreground whitespace-pre-wrap break-all">
+                  {oneLiner}
+                </pre>
+              </div>
+              <p className="text-[11px] text-muted-foreground/50">
+                This page updates automatically once the gateway connects.
+              </p>
+            </div>
+          )}
+
+          {(status === "starting" || status === "polling") && !oneLiner && (
+            <div className="rounded-xl border border-border/40 bg-card/20 p-4 space-y-3">
+              <div className="space-y-2">
+                {[
+                  { label: "Starting containers", threshold: 0 },
+                  { label: "Connecting to your database", threshold: 10 },
+                  { label: "Registering gateway", threshold: 20 },
+                ].map((s, i, arr) => {
+                  const active = elapsed >= s.threshold && (i === arr.length - 1 || elapsed < arr[i + 1].threshold);
+                  const done = i < arr.length - 1 && elapsed >= arr[i + 1].threshold;
+                  return (
+                    <div key={s.label} className="flex items-center gap-2.5">
+                      {done ? (
+                        <div className="flex h-4 w-4 items-center justify-center rounded-full bg-status-success">
+                          <Check className="h-2.5 w-2.5 text-primary-foreground" strokeWidth={3} />
+                        </div>
+                      ) : active ? (
+                        <Loader2 className="h-4 w-4 animate-spin text-primary" />
+                      ) : (
+                        <div className="h-4 w-4 rounded-full border border-border/60" />
+                      )}
+                      <span className={cn(
+                        "text-[12px] transition-colors",
+                        done ? "text-muted-foreground/50" : active ? "text-foreground font-medium" : "text-muted-foreground/40",
+                      )}>
+                        {s.label}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+              {elapsed >= 40 && (
+                <p className="text-[11px] text-status-warning animate-in fade-in duration-300">
+                  Taking longer than usual — make sure Docker is running.
+                </p>
+              )}
+            </div>
+          )}
+
+          {(status === "polling" || status === "starting") && (
+            <div className="flex items-center gap-2">
+              <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+              <span className="text-[12px] text-muted-foreground">Waiting for gateway to come online...</span>
+            </div>
+          )}
+
+          {status === "error" && error && (
+            <div className="flex items-start gap-2 rounded-lg border border-status-warning/30 bg-status-warning/[0.04] px-3 py-2.5 text-[12px] text-foreground">
+              <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-status-warning" />
+              <div className="space-y-0.5">
+                <span>{error}</span>
+                <p className="text-[11px] text-muted-foreground">
+                  Make sure Docker is running, then try again.
+                </p>
+              </div>
+            </div>
+          )}
+
+          <button
+            type="button"
+            onClick={onSkip}
+            className="text-[13px] text-muted-foreground/60 transition-colors hover:text-foreground"
+          >
+            Skip for now — I&apos;ll add a gateway later from Settings
+          </button>
+        </div>
+      )}
     </div>
   );
 }
@@ -718,7 +1267,7 @@ function AccountStep({
         {pending ? (
           <>
             <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            Creating workspace…
+            Creating workspace...
           </>
         ) : (
           <>
@@ -813,9 +1362,13 @@ function PaymentStep({
 
 function DoneStep({
   workspaceName,
+  agentName,
+  agentEmoji,
   onGoToDashboard,
 }: {
   workspaceName: string;
+  agentName?: string | null;
+  agentEmoji?: string | null;
   onGoToDashboard: () => void;
 }) {
   const [showContent, setShowContent] = useState(false);
@@ -851,7 +1404,11 @@ function DoneStep({
             {workspaceName} is ready
           </h1>
           <p className="text-[14px] text-muted-foreground">
-            Your new workspace has been created. Switch to it from the sidebar.
+            {agentName
+              ? `Your workspace and ${agentEmoji ?? ""} ${agentName} have been set up.`
+              : "Your new workspace has been created."
+            }
+            {" "}Switch to it from the sidebar.
           </p>
           <div className="pt-4">
             <button

--- a/apps/ui/src/components/workspaces/new-workspace-wizard.tsx
+++ b/apps/ui/src/components/workspaces/new-workspace-wizard.tsx
@@ -14,6 +14,8 @@ import {
   Copy,
   CheckCheck,
   ExternalLink,
+  Zap,
+  FileCode,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { StaggeredEntrance } from "@/components/onboarding/wizard/staggered-entrance";
@@ -26,6 +28,8 @@ import { AGENT_ROSTER, INTENT_TO_AGENT_KEY } from "@/lib/agents/roster";
 import {
   validateNewWorkspaceDb,
   confirmNewWorkspaceSchema,
+  runNewWorkspaceOneClickMigration,
+  extractProjectRefFromUrl,
   createHostedWorkspaceCheckout,
   registerNewWorkspaceDb,
   mintNewWorkspaceGatewayToken,
@@ -137,6 +141,10 @@ export function NewWorkspaceWizard({ isHosted, email: initialEmail }: Props) {
   const [schemaSql, setSchemaSql] = useState<string | null>(null);
   const [sqlEditorUrl, setSqlEditorUrl] = useState<string | null>(null);
   const [schemaConfirming, setSchemaConfirming] = useState(false);
+  const [projectRef, setProjectRef] = useState<string | null>(null);
+  const [migrationRunning, setMigrationRunning] = useState(false);
+  const [migrationError, setMigrationError] = useState<string | null>(null);
+  const [migrationHint, setMigrationHint] = useState<string | null>(null);
 
   useEffect(() => {
     return () => {
@@ -208,7 +216,12 @@ export function NewWorkspaceWizard({ isHosted, email: initialEmail }: Props) {
   const handleValidateDb = useCallback(() => {
     setDbStatus("validating");
     setDbError(null);
+    setMigrationError(null);
+    setMigrationHint(null);
     startTransition(async () => {
+      const ref = await extractProjectRefFromUrl(dbUrl.trim());
+      setProjectRef(ref);
+
       const r = await validateNewWorkspaceDb({
         url: dbUrl.trim(),
         anonKey: anonKey.trim(),
@@ -223,6 +236,7 @@ export function NewWorkspaceWizard({ isHosted, email: initialEmail }: Props) {
         setDbStatus("schema-needed");
         setSchemaSql(r.data.sql ?? null);
         setSqlEditorUrl(r.data.sqlEditorUrl ?? null);
+        if (r.data.projectRef) setProjectRef(r.data.projectRef);
       } else {
         setDbStatus("connected");
       }
@@ -245,6 +259,27 @@ export function NewWorkspaceWizard({ isHosted, email: initialEmail }: Props) {
       }
     });
   }, [dbUrl, anonKey, serviceRoleKey, startTransition]);
+
+  const handleRunOneClick = useCallback((region: string, dbPassword: string) => {
+    if (!projectRef) return;
+    setMigrationRunning(true);
+    setMigrationError(null);
+    setMigrationHint(null);
+    startTransition(async () => {
+      const r = await runNewWorkspaceOneClickMigration({
+        projectRef,
+        region,
+        dbPassword,
+      });
+      setMigrationRunning(false);
+      if (r.ok) {
+        setDbStatus("connected");
+      } else {
+        setMigrationError(r.error ?? "Migration failed");
+        setMigrationHint(r.hint ?? null);
+      }
+    });
+  }, [projectRef, startTransition]);
 
   const handleDbContinue = useCallback(() => {
     startTransition(async () => {
@@ -519,8 +554,13 @@ export function NewWorkspaceWizard({ isHosted, email: initialEmail }: Props) {
               schemaSql={schemaSql}
               sqlEditorUrl={sqlEditorUrl}
               schemaConfirming={schemaConfirming}
+              projectRef={projectRef}
+              migrationRunning={migrationRunning}
+              migrationError={migrationError}
+              migrationHint={migrationHint}
               onValidate={handleValidateDb}
               onConfirmSchema={handleConfirmSchema}
+              onRunOneClick={handleRunOneClick}
               onContinue={handleDbContinue}
               pending={pending}
             />
@@ -696,6 +736,279 @@ function NameStep({
 
 // ── Database Step (OSS) ────────────────────────────────────────────────────
 
+const SUPABASE_REGIONS = [
+  { value: "us-east-1", label: "US East (N. Virginia)" },
+  { value: "us-east-2", label: "US East (Ohio)" },
+  { value: "us-west-1", label: "US West (N. California)" },
+  { value: "us-west-2", label: "US West (Oregon)" },
+  { value: "ca-central-1", label: "Canada (Central)" },
+  { value: "eu-west-1", label: "EU West (Ireland)" },
+  { value: "eu-west-2", label: "EU West (London)" },
+  { value: "eu-west-3", label: "EU West (Paris)" },
+  { value: "eu-central-1", label: "EU Central (Frankfurt)" },
+  { value: "eu-central-2", label: "EU Central (Zurich)" },
+  { value: "eu-north-1", label: "EU North (Stockholm)" },
+  { value: "ap-south-1", label: "South Asia (Mumbai)" },
+  { value: "ap-southeast-1", label: "Southeast Asia (Singapore)" },
+  { value: "ap-southeast-2", label: "Oceania (Sydney)" },
+  { value: "ap-northeast-1", label: "Northeast Asia (Tokyo)" },
+  { value: "ap-northeast-2", label: "Northeast Asia (Seoul)" },
+  { value: "sa-east-1", label: "South America (Sao Paulo)" },
+];
+
+function SchemaInstallPanelNW({
+  schemaSql,
+  sqlEditorUrl,
+  schemaConfirming,
+  migrationRunning,
+  migrationError,
+  migrationHint,
+  projectRef,
+  onRunOneClick,
+  onConfirmSchema,
+}: {
+  schemaSql: string | null;
+  sqlEditorUrl: string | null;
+  schemaConfirming: boolean;
+  migrationRunning: boolean;
+  migrationError: string | null;
+  migrationHint: string | null;
+  projectRef: string | null;
+  onRunOneClick: (region: string, dbPassword: string) => void;
+  onConfirmSchema: () => void;
+}) {
+  const [showManual, setShowManual] = useState(false);
+  const [region, setRegion] = useState("us-east-1");
+  const [dbPassword, setDbPassword] = useState("");
+
+  const busy = migrationRunning || schemaConfirming;
+
+  return (
+    <div className="space-y-4 rounded-xl border border-status-warning/30 bg-status-warning/[0.04] px-4 py-4">
+      <div className="flex items-start gap-2">
+        <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-status-warning" />
+        <div className="space-y-0.5">
+          <p className="text-[13px] font-medium text-foreground">Your database needs HQ&apos;s tables</p>
+          <p className="text-[12px] text-muted-foreground">
+            HQ needs to create its tables in your Supabase database.
+            This is automatic and takes about 30 seconds, or you can run the SQL manually.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+        {/* Auto-install path */}
+        <div
+          role="button"
+          tabIndex={0}
+          onClick={() => setShowManual(false)}
+          onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setShowManual(false); } }}
+          className={cn(
+            "rounded-lg border p-4 transition-all",
+            !showManual
+              ? "border-foreground/20 bg-foreground/[0.02]"
+              : "border-border/40 bg-transparent cursor-pointer hover:border-border/60 hover:bg-foreground/[0.01]",
+          )}
+        >
+          <div className="flex items-center gap-2.5">
+            <div className={cn(
+              "flex h-7 w-7 items-center justify-center rounded-lg transition-colors",
+              !showManual ? "bg-primary/10 text-primary" : "bg-muted/60 text-muted-foreground/60",
+            )}>
+              <Zap className="h-3.5 w-3.5" />
+            </div>
+            <div className="flex-1">
+              <p className={cn(
+                "text-[12px] font-semibold",
+                !showManual ? "text-foreground" : "text-foreground/70",
+              )}>
+                Automatic install
+              </p>
+              {showManual && (
+                <p className="text-[11px] text-muted-foreground/50 mt-0.5">
+                  We handle everything — just provide your DB password
+                </p>
+              )}
+            </div>
+            {!showManual && (
+              <div className="flex h-4 w-4 items-center justify-center rounded-full bg-primary">
+                <Check className="h-2.5 w-2.5 text-primary-foreground" strokeWidth={3} />
+              </div>
+            )}
+          </div>
+          {!showManual && (
+            <div className="mt-3 space-y-3 animate-in fade-in duration-200" onClick={(e) => e.stopPropagation()}>
+              <div className="space-y-2">
+                <label className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground/70">
+                  Region
+                </label>
+                <select
+                  value={region}
+                  onChange={(e) => setRegion(e.target.value)}
+                  disabled={busy}
+                  className="flex h-9 w-full rounded-md border border-border/60 bg-background px-3 text-[13px] outline-none transition-colors focus:border-primary/40 focus:ring-1 focus:ring-primary/10 disabled:opacity-50"
+                >
+                  {SUPABASE_REGIONS.map((r) => (
+                    <option key={r.value} value={r.value}>{r.label}</option>
+                  ))}
+                </select>
+              </div>
+
+              <div className="space-y-1.5">
+                <label className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground/70">
+                  Database password
+                </label>
+                <input
+                  type="password"
+                  value={dbPassword}
+                  onChange={(e) => setDbPassword(e.target.value)}
+                  placeholder="Your Supabase database password"
+                  disabled={busy}
+                  className="flex h-9 w-full rounded-md border border-border/60 bg-background px-3 text-[13px] font-mono outline-none transition-colors placeholder:text-muted-foreground/40 focus:border-primary/40 focus:ring-1 focus:ring-primary/10 disabled:opacity-50"
+                />
+                <p className="text-[11px] text-muted-foreground/60">
+                  Set when you created the project. Find it in Settings {"->"} Database.
+                </p>
+              </div>
+
+              <button
+                type="button"
+                onClick={() => onRunOneClick(region, dbPassword)}
+                disabled={busy || !dbPassword.trim() || !projectRef}
+                className={cn(
+                  "inline-flex items-center gap-2 rounded-lg px-3.5 py-2 text-[12px] font-medium transition-all",
+                  busy || !dbPassword.trim() || !projectRef
+                    ? "cursor-not-allowed bg-muted text-muted-foreground/50"
+                    : "bg-foreground/[0.08] text-foreground hover:bg-foreground/[0.13]",
+                )}
+              >
+                {migrationRunning ? (
+                  <><Loader2 className="h-3 w-3 animate-spin" />Installing...</>
+                ) : "Install schema"}
+              </button>
+            </div>
+          )}
+        </div>
+
+        {/* Manual SQL path */}
+        <div
+          role="button"
+          tabIndex={0}
+          onClick={() => setShowManual(true)}
+          onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setShowManual(true); } }}
+          className={cn(
+            "rounded-lg border p-4 transition-all",
+            showManual
+              ? "border-foreground/20 bg-foreground/[0.02]"
+              : "border-border/40 bg-transparent cursor-pointer hover:border-border/60 hover:bg-foreground/[0.01]",
+          )}
+        >
+          <div className="flex items-center gap-2.5">
+            <div className={cn(
+              "flex h-7 w-7 items-center justify-center rounded-lg transition-colors",
+              showManual ? "bg-primary/10 text-primary" : "bg-muted/60 text-muted-foreground/60",
+            )}>
+              <FileCode className="h-3.5 w-3.5" />
+            </div>
+            <div className="flex-1">
+              <p className={cn(
+                "text-[12px] font-semibold",
+                showManual ? "text-foreground" : "text-foreground/70",
+              )}>
+                Manual SQL
+              </p>
+              {!showManual && (
+                <p className="text-[11px] text-muted-foreground/50 mt-0.5">
+                  Copy and run the SQL yourself in Supabase
+                </p>
+              )}
+            </div>
+            {showManual && (
+              <div className="flex h-4 w-4 items-center justify-center rounded-full bg-primary">
+                <Check className="h-2.5 w-2.5 text-primary-foreground" strokeWidth={3} />
+              </div>
+            )}
+          </div>
+          {showManual && (
+            <div className="mt-3 space-y-3 animate-in fade-in duration-200" onClick={(e) => e.stopPropagation()}>
+              <p className="text-[12px] text-muted-foreground">
+                Open your Supabase SQL editor, paste the script below, and click{" "}
+                <span className="font-medium text-foreground">Run</span>.
+              </p>
+
+              {sqlEditorUrl && (
+                <a
+                  href={sqlEditorUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 rounded-lg border border-border/60 bg-card/40 px-3 py-2 text-[12px] font-medium text-foreground transition-colors hover:bg-card/70"
+                >
+                  <ExternalLink className="h-3.5 w-3.5" />
+                  Open SQL editor
+                </a>
+              )}
+
+              {schemaSql && (
+                <div className="relative rounded-lg border border-border/40 bg-muted/30">
+                  <div className="absolute right-2 top-2">
+                    <CopyButtonInline text={schemaSql} />
+                  </div>
+                  <pre className="max-h-40 overflow-y-auto px-3 py-3 pr-8 text-[11px] leading-relaxed text-muted-foreground">
+                    {schemaSql.slice(0, 600)}{schemaSql.length > 600 ? "\n...(truncated)" : ""}
+                  </pre>
+                </div>
+              )}
+
+              <button
+                type="button"
+                onClick={onConfirmSchema}
+                disabled={busy}
+                className={cn(
+                  "inline-flex items-center gap-2 rounded-lg px-3.5 py-2 text-[12px] font-medium transition-all",
+                  busy
+                    ? "cursor-not-allowed bg-muted text-muted-foreground/50"
+                    : "bg-foreground/[0.08] text-foreground hover:bg-foreground/[0.13]",
+                )}
+              >
+                {schemaConfirming ? (
+                  <><Loader2 className="h-3 w-3 animate-spin" />Checking...</>
+                ) : "I ran it — verify"}
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {migrationError && (
+        <div className="space-y-0.5">
+          <p className="text-[12px] text-destructive">{migrationError}</p>
+          {migrationHint && (
+            <p className="text-[11px] text-muted-foreground">{migrationHint}</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CopyButtonInline({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        navigator.clipboard.writeText(text);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }}
+      className="rounded p-1 text-muted-foreground/60 transition-colors hover:text-foreground"
+      aria-label="Copy"
+    >
+      {copied ? <CheckCheck className="h-3.5 w-3.5 text-status-success" /> : <Copy className="h-3.5 w-3.5" />}
+    </button>
+  );
+}
+
 function DatabaseStep({
   dbUrl,
   anonKey,
@@ -708,8 +1021,13 @@ function DatabaseStep({
   schemaSql,
   sqlEditorUrl,
   schemaConfirming,
+  projectRef,
+  migrationRunning,
+  migrationError,
+  migrationHint,
   onValidate,
   onConfirmSchema,
+  onRunOneClick,
   onContinue,
   pending,
 }: {
@@ -724,20 +1042,17 @@ function DatabaseStep({
   schemaSql: string | null;
   sqlEditorUrl: string | null;
   schemaConfirming: boolean;
+  projectRef: string | null;
+  migrationRunning: boolean;
+  migrationError: string | null;
+  migrationHint: string | null;
   onValidate: () => void;
   onConfirmSchema: () => void;
+  onRunOneClick: (region: string, dbPassword: string) => void;
   onContinue: () => void;
   pending: boolean;
 }) {
-  const [copied, setCopied] = useState(false);
   const credsValid = dbUrl.includes("supabase") && anonKey.length >= 20 && serviceRoleKey.length >= 20;
-
-  const handleCopySql = () => {
-    if (!schemaSql) return;
-    navigator.clipboard.writeText(schemaSql);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
 
   return (
     <div className="space-y-6">
@@ -809,57 +1124,17 @@ function DatabaseStep({
       )}
 
       {status === "schema-needed" && (
-        <div className="space-y-3 rounded-lg border border-status-warning/30 bg-status-warning/5 p-4">
-          <p className="text-[13px] font-medium text-foreground">Schema required</p>
-          <p className="text-[12px] text-muted-foreground">
-            Run the SQL below in your Supabase SQL editor, then click &ldquo;Verify&rdquo;.
-          </p>
-          {sqlEditorUrl && (
-            <a
-              href={sqlEditorUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 text-[12px] text-foreground underline underline-offset-2"
-            >
-              Open SQL editor
-              <ExternalLink className="h-3 w-3" />
-            </a>
-          )}
-          {schemaSql && (
-            <div className="relative">
-              <pre className="max-h-40 overflow-auto rounded-md bg-muted/50 p-3 text-[11px] font-mono text-muted-foreground">
-                {schemaSql.slice(0, 500)}{schemaSql.length > 500 ? "..." : ""}
-              </pre>
-              <button
-                type="button"
-                onClick={handleCopySql}
-                className="absolute right-2 top-2 rounded-md bg-background/80 p-1.5 text-muted-foreground hover:text-foreground transition-colors"
-              >
-                {copied ? <CheckCheck className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-              </button>
-            </div>
-          )}
-          <button
-            type="button"
-            onClick={onConfirmSchema}
-            disabled={schemaConfirming}
-            className={cn(
-              "inline-flex items-center gap-2 rounded-full px-4 py-2 text-[12px] font-medium transition-all",
-              schemaConfirming
-                ? "cursor-wait bg-muted text-muted-foreground/50"
-                : "bg-primary text-primary-foreground shadow-sm hover:brightness-110",
-            )}
-          >
-            {schemaConfirming ? (
-              <>
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                Verifying...
-              </>
-            ) : (
-              "Verify schema"
-            )}
-          </button>
-        </div>
+        <SchemaInstallPanelNW
+          schemaSql={schemaSql}
+          sqlEditorUrl={sqlEditorUrl}
+          schemaConfirming={schemaConfirming}
+          migrationRunning={migrationRunning}
+          migrationError={migrationError}
+          migrationHint={migrationHint}
+          projectRef={projectRef}
+          onRunOneClick={onRunOneClick}
+          onConfirmSchema={onConfirmSchema}
+        />
       )}
 
       {status === "connected" && (

--- a/apps/ui/src/components/workspaces/new-workspace-wizard.tsx
+++ b/apps/ui/src/components/workspaces/new-workspace-wizard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState, useTransition } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { useSearchParams } from "next/navigation";
 import {
   ArrowLeft,
@@ -86,13 +86,6 @@ interface Props {
   email?: string;
 }
 
-const newWorkspaceOAuthActions: StepProviderActions = {
-  startOAuthFlow: startNewWorkspaceOAuth,
-  submitOAuthPaste: submitNewWorkspaceOAuthPaste,
-  pollCommandState: pollNewWorkspaceCommandState,
-  saveOAuthProvider: saveNewWorkspaceOAuthProvider,
-};
-
 export function NewWorkspaceWizard({ isHosted, email: initialEmail }: Props) {
   const searchParams = useSearchParams();
   const steps = isHosted ? HOSTED_STEPS : OSS_STEPS;
@@ -110,7 +103,7 @@ export function NewWorkspaceWizard({ isHosted, email: initialEmail }: Props) {
   const [dbUrl, setDbUrl] = useState("");
   const [anonKey, setAnonKey] = useState("");
   const [serviceRoleKey, setServiceRoleKey] = useState("");
-  const [_workspaceId, setWorkspaceId] = useState<string | null>(null);
+  const [workspaceId, setWorkspaceId] = useState<string | null>(null);
   const [accountEmail, setAccountEmail] = useState(initialEmail ?? "");
   const [password, setPassword] = useState("");
   const [hostedWorkspaceId, setHostedWorkspaceId] = useState<string | null>(null);
@@ -145,6 +138,17 @@ export function NewWorkspaceWizard({ isHosted, email: initialEmail }: Props) {
   const [migrationRunning, setMigrationRunning] = useState(false);
   const [migrationError, setMigrationError] = useState<string | null>(null);
   const [migrationHint, setMigrationHint] = useState<string | null>(null);
+
+  const oauthActions: StepProviderActions = useMemo(() => ({
+    startOAuthFlow: (provider, mode) =>
+      startNewWorkspaceOAuth(workspaceId!, provider, mode),
+    submitOAuthPaste: (parentCommandId, value) =>
+      submitNewWorkspaceOAuthPaste(workspaceId!, parentCommandId, value),
+    pollCommandState: (commandId) =>
+      pollNewWorkspaceCommandState(workspaceId!, commandId),
+    saveOAuthProvider: (provider) =>
+      saveNewWorkspaceOAuthProvider(workspaceId!, provider),
+  }), [workspaceId]);
 
   useEffect(() => {
     return () => {
@@ -316,7 +320,7 @@ export function NewWorkspaceWizard({ isHosted, email: initialEmail }: Props) {
           setGatewayStatus("polling");
         }
       } else {
-        const r = await mintNewWorkspaceGatewayToken();
+        const r = await mintNewWorkspaceGatewayToken(workspaceId!);
         if (!r.ok || !r.data) {
           setGatewayStatus("error");
           setGatewayError(r.error ?? "Failed to mint token");
@@ -329,14 +333,14 @@ export function NewWorkspaceWizard({ isHosted, email: initialEmail }: Props) {
 
       if (pollRef.current) clearInterval(pollRef.current);
       pollRef.current = setInterval(async () => {
-        const poll = await pollNewWorkspaceGateway();
+        const poll = await pollNewWorkspaceGateway(workspaceId!);
         if (poll.ok && poll.data?.status === "ready") {
           if (pollRef.current) clearInterval(pollRef.current);
           setGatewayStatus("connected");
         }
       }, 3000);
     });
-  }, [startTransition]);
+  }, [startTransition, workspaceId]);
 
   const handleGatewaySkip = useCallback(() => {
     if (pollRef.current) clearInterval(pollRef.current);
@@ -353,7 +357,7 @@ export function NewWorkspaceWizard({ isHosted, email: initialEmail }: Props) {
     setValidating(true);
     setValidationError(null);
     startTransition(async () => {
-      const r = await connectNewWorkspaceProvider(provider, apiKey);
+      const r = await connectNewWorkspaceProvider(workspaceId!, provider, apiKey);
       setValidating(false);
       if (r.ok) {
         setValidated(true);
@@ -363,7 +367,7 @@ export function NewWorkspaceWizard({ isHosted, email: initialEmail }: Props) {
         setValidationError(r.error ?? "Could not validate key");
       }
     });
-  }, [startTransition, advance]);
+  }, [startTransition, advance, workspaceId]);
 
   // ─── Agent step ───
   const getRecommendedKey = (): string => {
@@ -373,7 +377,7 @@ export function NewWorkspaceWizard({ isHosted, email: initialEmail }: Props) {
 
   const handleCreateAgent = useCallback(
     async (agentData: { name: string; emoji: string; templateBranch: string }) => {
-      const r = await createNewWorkspaceAgent({
+      const r = await createNewWorkspaceAgent(workspaceId!, {
         agentName: agentData.name,
         agentEmoji: agentData.emoji,
         templateBranch: agentData.templateBranch,
@@ -390,9 +394,10 @@ export function NewWorkspaceWizard({ isHosted, email: initialEmail }: Props) {
       setProvisionStatus("provisioning");
 
       if (provisionCommandId) {
+        const wsId = workspaceId!;
         const startedAt = Date.now();
         const interval = setInterval(async () => {
-          const status = await pollNewWorkspaceAgentProvision(provisionCommandId);
+          const status = await pollNewWorkspaceAgentProvision(wsId, provisionCommandId);
           if (status === "completed") {
             clearInterval(interval);
             setProvisionStatus("ready");
@@ -409,7 +414,7 @@ export function NewWorkspaceWizard({ isHosted, email: initialEmail }: Props) {
 
       return { agentId, provisionCommandId };
     },
-    [providerId],
+    [providerId, workspaceId],
   );
 
   const agentDoneFired = useRef(false);
@@ -429,7 +434,7 @@ export function NewWorkspaceWizard({ isHosted, email: initialEmail }: Props) {
   // ─── Account step (OSS) ───
   const handleCreateWorkspace = useCallback(() => {
     startTransition(async () => {
-      const r = await finalizeNewWorkspace({
+      const r = await finalizeNewWorkspace(workspaceId!, {
         email: accountEmail.trim(),
         password,
         contextPresetKey: intentKey,
@@ -452,7 +457,7 @@ export function NewWorkspaceWizard({ isHosted, email: initialEmail }: Props) {
       }
       advance();
     });
-  }, [accountEmail, password, intentKey, label, startTransition, advance]);
+  }, [accountEmail, password, intentKey, label, startTransition, advance, workspaceId]);
 
   // ─── Payment step (Hosted) ───
   const handlePaymentCheckout = useCallback(async () => {
@@ -588,7 +593,7 @@ export function NewWorkspaceWizard({ isHosted, email: initialEmail }: Props) {
               validationError={validationError}
               isHosted={false}
               collectOnly={false}
-              actions={newWorkspaceOAuthActions}
+              actions={oauthActions}
             />
           )}
 

--- a/apps/ui/src/components/workspaces/workspace-switcher.tsx
+++ b/apps/ui/src/components/workspaces/workspace-switcher.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Plus, Check, ChevronsUpDown, Settings } from "lucide-react";
@@ -12,7 +11,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { AddWorkspaceDialog } from "./add-workspace-dialog";
 import { cn } from "@/lib/utils";
 
 
@@ -46,10 +44,9 @@ export function WorkspaceSwitcher({
   activeWorkspaceId,
   workspaces,
   showLabels = true,
-  isHosted = false,
+  isHosted: _isHosted = false,
 }: Props) {
   const router = useRouter();
-  const [addOpen, setAddOpen] = useState(false);
   const active =
     workspaces.find((w) => w.id === activeWorkspaceId) ?? workspaces[0] ?? null;
 
@@ -62,21 +59,6 @@ export function WorkspaceSwitcher({
         {showLabels && (
           <span className="truncate text-[13px] font-semibold tracking-tight text-foreground">
             HQ
-          </span>
-        )}
-      </div>
-    );
-  }
-
-  if (workspaces.length <= 1) {
-    return (
-      <div className="flex h-12 shrink-0 items-center gap-2 px-3">
-        <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-muted text-[13px]">
-          {active.emoji}
-        </div>
-        {showLabels && (
-          <span className="truncate text-[13px] font-semibold tracking-tight text-foreground">
-            {active.label}
           </span>
         )}
       </div>
@@ -140,11 +122,7 @@ export function WorkspaceSwitcher({
             <DropdownMenuSeparator />
             <DropdownMenuItem
               onSelect={() => {
-                if (isHosted) {
-                  router.push("/new-workspace");
-                } else {
-                  setAddOpen(true);
-                }
+                router.push("/new-workspace");
               }}
               className="gap-2"
             >
@@ -160,13 +138,6 @@ export function WorkspaceSwitcher({
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
-      <AddWorkspaceDialog
-        open={addOpen}
-        onOpenChange={setAddOpen}
-        onAdded={() => {
-          window.location.reload();
-        }}
-      />
     </>
   );
 }

--- a/apps/ui/src/lib/agents/roster.ts
+++ b/apps/ui/src/lib/agents/roster.ts
@@ -1,0 +1,127 @@
+export interface AgentCapability {
+  label: string;
+  detail: string;
+}
+
+export interface AgentTemplate {
+  key: string;
+  branch: string;
+  name: string;
+  emoji: string;
+  role: string;
+  description: string;
+  capabilities: AgentCapability[];
+}
+
+export const AGENT_ROSTER: AgentTemplate[] = [
+  {
+    key: "scout", branch: "template/crm-researcher", name: "Scout", emoji: "\u{1F575}️", role: "Sales & Outreach",
+    description: "Your dedicated sales partner — researches targets, crafts outreach, and keeps your pipeline moving.",
+    capabilities: [
+      { label: "Prospect research", detail: "Deep-dives into companies, finds decision-makers, and builds target profiles" },
+      { label: "Outreach drafting", detail: "Writes personalized emails and messages tailored to each prospect" },
+      { label: "Pipeline tracking", detail: "Keeps your deals organized and flags follow-ups before they slip" },
+      { label: "Meeting prep", detail: "Summarizes notes, tracks next steps, and preps you before every call" },
+    ],
+  },
+  {
+    key: "ghost", branch: "template/ghostwriter", name: "Ghost", emoji: "\u{1F469}‍\u{1F4BB}", role: "Content Writer",
+    description: "Your writing partner — drafts in your voice, researches topics, and keeps your content calendar full.",
+    capabilities: [
+      { label: "Content drafting", detail: "Writes newsletters, blog posts, and social threads in your voice" },
+      { label: "Topic research", detail: "Finds angles, pulls sources, and builds outlines before you write" },
+      { label: "Editing & refinement", detail: "Tightens drafts, adjusts tone, and incorporates your feedback" },
+      { label: "Calendar planning", detail: "Plans your publishing schedule and tracks what's due next" },
+    ],
+  },
+  {
+    key: "chief", branch: "template/chief-of-staff", name: "Chief", emoji: "\u{1F9B8}", role: "Operations",
+    description: "Your operations lead — coordinates work, tracks clients, and keeps everything on schedule.",
+    capabilities: [
+      { label: "Task management", detail: "Breaks down projects, assigns priorities, and tracks progress" },
+      { label: "Client tracking", detail: "Keeps accounts organized with status, notes, and next actions" },
+      { label: "Blocker alerts", detail: "Surfaces overdue items and bottlenecks before they become problems" },
+      { label: "Status updates", detail: "Prepares summaries and reports so you always know where things stand" },
+    ],
+  },
+  {
+    key: "researcher", branch: "template/assistant", name: "Researcher", emoji: "\u{1F9D1}‍\u{1F52C}", role: "Research & Analysis",
+    description: "Your research analyst — digs deep into topics, synthesizes findings, and keeps your knowledge organized.",
+    capabilities: [
+      { label: "Deep research", detail: "Investigates markets, companies, and trends with structured analysis" },
+      { label: "Brief creation", detail: "Synthesizes findings into clear, actionable summaries" },
+      { label: "Monitoring", detail: "Tracks topics over time and surfaces new developments" },
+      { label: "Knowledge organization", detail: "Files research into your knowledge base so nothing gets lost" },
+    ],
+  },
+  {
+    key: "assistant", branch: "template/assistant", name: "Assistant", emoji: "\u{1F9D1}‍\u{1F4BC}", role: "General Assistant",
+    description: "Your right hand — manages tasks, tracks what matters, and handles the day-to-day so you can focus.",
+    capabilities: [
+      { label: "Task management", detail: "Organizes your to-dos, sets priorities, and tracks deadlines" },
+      { label: "Research & writing", detail: "Looks into topics and drafts docs, messages, and quick write-ups" },
+      { label: "Project tracking", detail: "Monitors progress across workstreams and flags what needs attention" },
+      { label: "Workspace upkeep", detail: "Keeps everything organized, up to date, and easy to find" },
+    ],
+  },
+  {
+    key: "cofounder", branch: "template/cofounder", name: "Co-Founder", emoji: "\u{1F680}", role: "Strategy & Execution",
+    description: "Your strategic operator — helps drive execution, shape direction, and keep the business moving.",
+    capabilities: [
+      { label: "Strategic planning", detail: "Breaks down big goals into actionable next steps" },
+      { label: "Decision support", detail: "Frames trade-offs and surfaces the data you need to decide" },
+      { label: "Execution tracking", detail: "Keeps initiatives on track and flags when things stall" },
+      { label: "Market awareness", detail: "Monitors competitors, trends, and opportunities" },
+    ],
+  },
+  {
+    key: "cmo", branch: "template/cmo", name: "CMO", emoji: "\u{1F4E1}", role: "Marketing Strategy",
+    description: "Your marketing strategist — designs messaging, plans campaigns, and builds your funnel.",
+    capabilities: [
+      { label: "Campaign strategy", detail: "Plans multi-channel campaigns aligned to your goals" },
+      { label: "Messaging & positioning", detail: "Crafts clear value props that resonate with your audience" },
+      { label: "Funnel design", detail: "Maps the journey from awareness to conversion" },
+      { label: "Performance analysis", detail: "Tracks what's working and recommends where to double down" },
+    ],
+  },
+  {
+    key: "analytics", branch: "template/analytics", name: "Analytics", emoji: "\u{1F4CA}", role: "Data & Insights",
+    description: "Your performance analyst — turns activity and outcomes into clear metrics and action items.",
+    capabilities: [
+      { label: "Metric tracking", detail: "Monitors KPIs and highlights meaningful changes" },
+      { label: "Trend analysis", detail: "Spots patterns in your data and explains what's driving them" },
+      { label: "Reporting", detail: "Builds clear dashboards and summaries for stakeholders" },
+      { label: "Recommendations", detail: "Translates insights into specific next steps" },
+    ],
+  },
+  {
+    key: "designer", branch: "template/designer", name: "Designer", emoji: "\u{1F3A8}", role: "Visual Design",
+    description: "Your visual creator — turns ideas into clear, engaging graphics and polished content.",
+    capabilities: [
+      { label: "Graphic creation", detail: "Designs social graphics, presentations, and brand assets" },
+      { label: "Content formatting", detail: "Polishes docs and decks for a professional look" },
+      { label: "Brand consistency", detail: "Keeps your visual identity cohesive across everything" },
+      { label: "Creative concepts", detail: "Explores visual directions and translates ideas into layouts" },
+    ],
+  },
+  {
+    key: "market-researcher", branch: "template/market-researcher", name: "Market Intel", emoji: "\u{1F52E}", role: "Market Intelligence",
+    description: "Your external intelligence agent — scans markets, spots patterns, and surfaces meaningful signals.",
+    capabilities: [
+      { label: "Competitive analysis", detail: "Tracks competitors, their moves, and positioning shifts" },
+      { label: "Market scanning", detail: "Monitors industry trends and emerging opportunities" },
+      { label: "Signal detection", detail: "Surfaces news, funding rounds, and key market events" },
+      { label: "Intelligence briefs", detail: "Delivers structured summaries you can act on quickly" },
+    ],
+  },
+];
+
+export const INTENT_TO_AGENT_KEY: Record<string, string> = {
+  reach: "scout",
+  publish: "ghost",
+  run: "chief",
+  hire: "scout",
+  research: "researcher",
+  organized: "assistant",
+  explore: "assistant",
+};

--- a/apps/ui/src/lib/setup/run-complete-setup.ts
+++ b/apps/ui/src/lib/setup/run-complete-setup.ts
@@ -1,0 +1,182 @@
+import "server-only";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  PIPELINE_TEMPLATES,
+  FIELD_TEMPLATES,
+  DEFAULT_STREAMS,
+  DEFAULT_CONTEXT_PRESET,
+  findPreset,
+} from "@/lib/setup/templates";
+
+export async function runCompleteSetup(
+  supabase: SupabaseClient,
+  params: {
+    workspaceName: string;
+    workspaceSlug?: string | null;
+    workspaceDescription?: string;
+    ownerName?: string;
+    preferredName?: string;
+    timezone?: string;
+    contextPresetKey?: string | null;
+  },
+): Promise<{ ok: boolean; error?: string }> {
+  const workspaceName = params.workspaceName || "HQ";
+  const workspaceSlug = params.workspaceSlug ?? null;
+  const workspaceDescription = params.workspaceDescription ?? "";
+  const ownerName = params.ownerName ?? "";
+  const preferredName = params.preferredName ?? ownerName;
+  const timezone = params.timezone ?? "";
+
+  const presetKey = params.contextPresetKey ?? null;
+  const preset = presetKey ? findPreset(presetKey) : DEFAULT_CONTEXT_PRESET;
+
+  const pipelineKey = preset.pipelineKey;
+  const fieldKey = preset.fieldKey;
+  const streamNames = preset.streamNames;
+
+  const pipelineTemplate = PIPELINE_TEMPLATES.find((t) => t.key === pipelineKey);
+  const fieldTemplate = FIELD_TEMPLATES.find((t) => t.key === fieldKey);
+  if (!pipelineTemplate || !fieldTemplate) {
+    return { ok: false, error: "Pipeline or field template not found" };
+  }
+
+  const enabledStreams = DEFAULT_STREAMS.filter((s) => streamNames.includes(s.name));
+  const defaultNames = new Set(DEFAULT_STREAMS.map((s) => s.name));
+  const customStreams = streamNames
+    .filter((name) => !defaultNames.has(name))
+    .map((name, i) => ({
+      name,
+      description: null,
+      type: "custom" as const,
+      color: "#6b7280",
+      icon: null,
+      sort_order: enabledStreams.length + i,
+    }));
+  const allStreams = [...enabledStreams, ...customStreams];
+
+  const stagesJson = pipelineTemplate.stages.map((s) => ({
+    stage_key: s.stage_key,
+    label: s.label,
+    color: s.color,
+    sort_order: s.sort_order,
+    is_terminal: s.is_terminal,
+    is_default: s.is_default,
+  }));
+
+  const fieldsJson = fieldTemplate.fields.map((f) => ({
+    field_key: f.field_key,
+    field_type: f.field_type,
+    label: f.label,
+    field_group: f.field_group,
+    sort_order: f.sort_order,
+    required: f.required,
+    options: f.options,
+    description: f.description,
+  }));
+
+  const streamsJson = allStreams.map((s) => ({
+    name: s.name,
+    description: s.description,
+    type: s.type,
+    color: s.color,
+    icon: s.icon,
+    sort_order: s.sort_order,
+  }));
+
+  const { error } = await supabase.rpc("complete_setup", {
+    p_name: workspaceName,
+    p_slug: workspaceSlug,
+    p_description: workspaceDescription,
+    p_owner_name: ownerName,
+    p_preferred_name: preferredName,
+    p_timezone: timezone,
+    p_stages: stagesJson,
+    p_fields: fieldsJson,
+    p_streams: streamsJson,
+    p_tenant_id: "00000000-0000-0000-0000-000000000000",
+  });
+  if (error) return { ok: false, error: error.message };
+
+  const modules = preset.modules ?? { crm: true };
+  await supabase
+    .from("workspace")
+    .update({
+      settings: { modules },
+    })
+    .eq("tenant_id", "00000000-0000-0000-0000-000000000000");
+
+  if (preset.collectionTemplateSlugs?.length) {
+    for (const slug of preset.collectionTemplateSlugs) {
+      const { data: tpl } = await supabase
+        .from("collection_templates")
+        .select("definition")
+        .eq("slug", slug)
+        .maybeSingle();
+      if (!tpl?.definition) continue;
+
+      const def = tpl.definition as {
+        name?: string;
+        description?: string;
+        icon?: string;
+        color?: string;
+        fields?: Array<Record<string, unknown>>;
+        views?: Array<Record<string, unknown>>;
+      };
+
+      const { data: existing } = await supabase
+        .from("collection_definitions")
+        .select("id")
+        .eq("slug", slug)
+        .eq("tenant_id", "00000000-0000-0000-0000-000000000000")
+        .maybeSingle();
+      if (existing) continue;
+
+      const { data: created } = await supabase
+        .from("collection_definitions")
+        .insert({
+          name: def.name ?? slug,
+          slug,
+          description: def.description ?? null,
+          icon: def.icon ?? null,
+          color: def.color ?? "#6b7280",
+          tenant_id: "00000000-0000-0000-0000-000000000000",
+        })
+        .select("id")
+        .single();
+      if (!created) continue;
+
+      if (def.fields?.length) {
+        await supabase.from("collection_fields").insert(
+          def.fields.map((f, i) => ({
+            collection_id: created.id,
+            field_key: f.field_key,
+            field_type: f.field_type,
+            label: f.label,
+            sort_order: f.sort_order ?? i,
+            required: f.required ?? false,
+            options: f.options ?? null,
+            is_title_field: f.is_title_field ?? false,
+            tenant_id: "00000000-0000-0000-0000-000000000000",
+          })),
+        );
+      }
+
+      if (def.views?.length) {
+        await supabase.from("collection_views").insert(
+          def.views.map((v, i) => ({
+            collection_id: created.id,
+            name: v.name,
+            view_type: v.view_type,
+            config: v.config ?? {},
+            is_default: v.is_default ?? i === 0,
+            sort_order: v.sort_order ?? i,
+            tenant_id: "00000000-0000-0000-0000-000000000000",
+          })),
+        );
+      }
+    }
+  }
+
+  return { ok: true };
+}

--- a/db/migrations/003_shared_functions.sql
+++ b/db/migrations/003_shared_functions.sql
@@ -34,6 +34,7 @@ CREATE TABLE IF NOT EXISTS _schema_version (
   applied_at  timestamptz NOT NULL DEFAULT now(),
   description text
 );
+ALTER TABLE _schema_version DISABLE ROW LEVEL SECURITY;
 GRANT SELECT ON _schema_version TO authenticated, service_role;
 
 INSERT INTO _schema_version (version, description)

--- a/gateway/daemons/inbox_dispatcher.py
+++ b/gateway/daemons/inbox_dispatcher.py
@@ -209,7 +209,7 @@ class WakeTracker:
                 {
                     "select": "id",
                     "agent_id": f"eq.{agent_id}",
-                    "or": "(status.eq.pending,and(status.eq.failed,attempt_count.lt.3))",
+                    "or": f"(status.eq.pending,and(status.eq.failed,attempt_count.lt.3),and(status.eq.leased,leased_until.lt.{now_iso()}))",
                     "limit": "1",
                 },
             )
@@ -350,7 +350,7 @@ def reconcile(tracker):
             "agent_inbox_items",
             {
                 "select": "agent_slug,agent_id",
-                "or": "(status.eq.pending,and(status.eq.failed,attempt_count.lt.3))",
+                "or": f"(status.eq.pending,and(status.eq.failed,attempt_count.lt.3),and(status.eq.leased,leased_until.lt.{now_iso()}))",
                 "limit": "100",
             },
         )

--- a/gateway/tests/test_inbox_dispatcher.py
+++ b/gateway/tests/test_inbox_dispatcher.py
@@ -61,7 +61,7 @@ def test_should_wake_returns_false_when_budget_hard_exceeded(tracker, monkeypatc
         if "agents" in table:
             return [{"status": "active"}]
         if "agent_inbox_items" in table:
-            if "leased" in str(params):
+            if params.get("status") == "eq.leased":
                 return []
             return [{"id": "item-1"}]
         if "agent_budgets" in table:
@@ -115,7 +115,7 @@ def test_wake_agent_passes_model_and_thinking_overrides(monkeypatch):
         if "agents" in table:
             return [{"status": "active"}]
         if "agent_inbox_items" in table:
-            if "leased" in str(params):
+            if params.get("status") == "eq.leased":
                 return []
             return [{"id": "item-1"}]
         if "agent_budgets" in table:
@@ -162,7 +162,7 @@ def test_wake_agent_without_overrides(monkeypatch):
         if "agents" in table:
             return [{"status": "active"}]
         if "agent_inbox_items" in table:
-            if "leased" in str(params):
+            if params.get("status") == "eq.leased":
                 return []
             return [{"id": "item-1"}]
         if "agent_budgets" in table:
@@ -204,7 +204,7 @@ def test_handle_new_item_enriches_task_assignment_with_blockers(monkeypatch):
         if "agents" in table:
             return [{"status": "active"}]
         if "agent_inbox_items" in table:
-            if "leased" in str(params):
+            if params.get("status") == "eq.leased":
                 return []
             return [{"id": "item-1"}]
         if "agent_budgets" in table:
@@ -259,7 +259,7 @@ def test_handle_new_item_no_blockers_no_enrichment(monkeypatch):
         if "agents" in table:
             return [{"status": "active"}]
         if "agent_inbox_items" in table:
-            if "leased" in str(params):
+            if params.get("status") == "eq.leased":
                 return []
             return [{"id": "item-1"}]
         if "agent_budgets" in table:
@@ -315,7 +315,7 @@ def test_handle_new_item_non_task_assignment_skips_enrichment(monkeypatch):
         if "agents" in table:
             return [{"status": "active"}]
         if "agent_inbox_items" in table:
-            if "leased" in str(params):
+            if params.get("status") == "eq.leased":
                 return []
             return [{"id": "item-1"}]
         if "agent_budgets" in table:
@@ -402,8 +402,6 @@ def test_should_wake_returns_false_when_no_actionable_work(monkeypatch):
         if "agents" in table:
             return [{"status": "active"}]
         if "agent_inbox_items" in table:
-            if "leased" in str(params):
-                return []
             return []
         if "agent_budgets" in table:
             return []
@@ -427,7 +425,7 @@ def test_should_wake_returns_false_when_active_lease(monkeypatch):
         if "agents" in table:
             return [{"status": "active"}]
         if "agent_inbox_items" in table:
-            if "leased" in str(params):
+            if params.get("status") == "eq.leased":
                 return [{"id": "leased-item"}]
             return [{"id": "item-1"}]
         if "agent_budgets" in table:


### PR DESCRIPTION
## Summary

Brings the "Add Workspace" flow to full parity with the initial onboarding wizard, plus multi-workspace auth improvements and several bug fixes.

### New workspace flow
- **Full 7-step wizard**: Name → Focus → Database → Gateway → AI Provider → Agent → Account → Done (was: Name → Database → Account → Done)
- **One-click auto-migration**: Enter DB password + region → runs all 37 migrations via Supabase pooler (no manual SQL paste needed)
- **Gateway step**: Local (Docker) or Remote (one-liner) with polling, plus "Skip for now" option
- **Provider step**: Reuses onboarding's StepProvider with injectable OAuth actions
- **Agent step**: Reuses onboarding's StepAgent with shared roster
- **`complete_setup()` called**: Workspaces are properly initialized with pipeline stages, fields, streams, and modules — no more `initialized: false` redirect loops
- **Deferred cookie switch**: The active workspace cookie only changes after account creation succeeds, so bailing mid-wizard doesn't lock you out of your current workspace

### Multi-workspace login
- Single login attempt authenticates across all registered workspaces in parallel
- Per-workspace session cookies — switching between authenticated workspaces is instant (no re-login)
- Landing workspace: prefers currently active if credentials match, otherwise first match

### Workspace switcher
- Always shows the dropdown (even with 1 workspace) with "Add workspace" CTA
- Routes to `/new-workspace` for both OSS and hosted modes

### Shared modules (DRY)
- `lib/agents/roster.ts` — extracted `AGENT_ROSTER`, `AgentTemplate`, `INTENT_TO_AGENT_KEY` from onboarding wizard
- `lib/setup/run-complete-setup.ts` — extracted `complete_setup` RPC logic, shared between onboarding and new-workspace flows
- `StepProvider` OAuth actions injectable via props for reuse outside onboarding

### Bug fixes
- **Expired inbox lease retry**: Dispatcher reconciliation now picks up items where `status=leased` but `leased_until` has expired, preventing permanently stuck tasks
- **Agent failure visibility**: Task form shows a warning banner when the assigned agent has failed to process after multiple attempts
- **Stale connection handling**: Connection delete gracefully handles "not found" errors after gateway respawn instead of showing a confusing error
- Tests added for `run-complete-setup` and `agents/roster` shared modules

## Test plan

- [ ] Create a new workspace via the full wizard (Name → Focus → DB → Gateway → Provider → Agent → Account)
- [ ] Verify one-click migration works (DB password + region)
- [ ] Verify gateway connects (local or remote)
- [ ] Verify agent provisions with correct name and template
- [ ] Verify `complete_setup()` runs (no redirect loop on dashboard)
- [ ] Verify auto-sign-in after wizard completes (no login page)
- [ ] Verify multi-workspace login (credentials tried against all workspaces)
- [ ] Verify workspace switching with existing sessions (no re-login)
- [ ] Verify bailing mid-wizard keeps you logged into previous workspace
- [ ] Verify expired inbox items are retried by dispatcher
- [ ] Verify task shows failure warning when agent repeatedly fails
- [ ] Verify deleting a stale connection after gateway respawn works

🤖 Generated with [Claude Code](https://claude.com/claude-code)