### PR TITLE
fix: openclaw 6.1 compatibility for gateway and connections UI

### DIFF
--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yourhq-ui",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yourhq-ui",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "dependencies": {
         "@base-ui/react": "^1.5.0",
         "@dnd-kit/core": "^6.3.1",

--- a/apps/ui/src/__tests__/lib/connections-parse-status.test.ts
+++ b/apps/ui/src/__tests__/lib/connections-parse-status.test.ts
@@ -264,4 +264,32 @@ describe("parseModelsStatus", () => {
     expect(result).toHaveLength(1);
     expect(result[0].provider).toBe("valid");
   });
+
+  test("captures authType from the profile type field (openclaw >=6.x)", () => {
+    const stdout = JSON.stringify({
+      auth: {
+        oauth: [
+          { provider: "openai", profile: "default", reason: "ok", type: "oauth" },
+        ],
+        providers: {
+          anthropic: {
+            profiles: [{ profile: "default", reason: "ok", type: "api_key" }],
+          },
+        },
+      },
+    });
+    const result = parseModelsStatus(stdout, GATEWAY);
+    const openai = result.find((c) => c.provider === "openai");
+    const anthropic = result.find((c) => c.provider === "anthropic");
+    expect(openai?.authType).toBe("oauth");
+    expect(anthropic?.authType).toBe("api_key");
+  });
+
+  test("authType is undefined when the type field is absent", () => {
+    const stdout = JSON.stringify({
+      auth: { oauth: [{ provider: "openai", reason: "ok" }] },
+    });
+    const result = parseModelsStatus(stdout, GATEWAY);
+    expect(result[0].authType).toBeUndefined();
+  });
 });

--- a/apps/ui/src/__tests__/lib/connections-provider-catalog.test.ts
+++ b/apps/ui/src/__tests__/lib/connections-provider-catalog.test.ts
@@ -1,0 +1,68 @@
+import { describe, test, expect } from "vitest";
+import {
+  getProviderCatalog,
+  getProviderCatalogForConnection,
+  PROVIDER_CATALOG,
+} from "@/lib/connections/types";
+
+describe("getProviderCatalogForConnection", () => {
+  // openclaw >=6.x reports both ChatGPT-OAuth and API-key credentials under
+  // provider "openai"; the connection's authType disambiguates display.
+
+  test("openai + oauth resolves to the ChatGPT catalog entry", () => {
+    const entry = getProviderCatalogForConnection("openai", "oauth");
+    expect(entry?.id).toBe("openai-codex");
+    expect(entry?.displayName).toBe("OpenAI (ChatGPT)");
+  });
+
+  test("openai + api_key resolves to the API-key catalog entry", () => {
+    const entry = getProviderCatalogForConnection("openai", "api_key");
+    expect(entry?.id).toBe("openai");
+    expect(entry?.displayName).toBe("OpenAI (API key)");
+  });
+
+  test("openai without authType falls back to the exact-id entry", () => {
+    const entry = getProviderCatalogForConnection("openai");
+    expect(entry?.id).toBe("openai");
+  });
+
+  test("legacy openai-codex id still resolves", () => {
+    const entry = getProviderCatalogForConnection("openai-codex");
+    expect(entry?.id).toBe("openai-codex");
+  });
+
+  test("google + oauth resolves to the Gemini CLI entry", () => {
+    const entry = getProviderCatalogForConnection("google", "oauth");
+    expect(entry?.id).toBe("google-gemini-cli");
+  });
+
+  test("google + api_key resolves to the base google entry", () => {
+    const entry = getProviderCatalogForConnection("google", "api_key");
+    expect(entry?.id).toBe("google");
+  });
+
+  test("single-entry providers resolve regardless of authType", () => {
+    expect(getProviderCatalogForConnection("anthropic", "api_key")?.id).toBe("anthropic");
+    expect(getProviderCatalogForConnection("anthropic", "oauth")?.id).toBe("anthropic");
+    expect(getProviderCatalogForConnection("anthropic")?.id).toBe("anthropic");
+  });
+
+  test("unknown provider returns undefined", () => {
+    expect(getProviderCatalogForConnection("nope")).toBeUndefined();
+  });
+});
+
+describe("PROVIDER_CATALOG gateway mapping", () => {
+  test("openai-codex maps to gateway provider openai", () => {
+    expect(getProviderCatalog("openai-codex")?.gatewayProvider).toBe("openai");
+  });
+
+  test("google-gemini-cli maps to gateway provider google", () => {
+    expect(getProviderCatalog("google-gemini-cli")?.gatewayProvider).toBe("google");
+  });
+
+  test("catalog ids are unique", () => {
+    const ids = PROVIDER_CATALOG.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/apps/ui/src/components/connections/connections-settings.tsx
+++ b/apps/ui/src/components/connections/connections-settings.tsx
@@ -40,7 +40,7 @@ import {
 } from "@/app/dashboard/settings/connections/actions";
 import {
   CONNECTION_STATUS_META,
-  getProviderCatalog,
+  getProviderCatalogForConnection,
   type Connection,
   type ConnectionStatus,
 } from "@/lib/connections/types";
@@ -125,7 +125,7 @@ export function ConnectionsSettings({
   }, [gatewayId, refresh]);
 
   const onSetDefault = useCallback(async (c: Connection) => {
-    const catalog = getProviderCatalog(c.provider);
+    const catalog = getProviderCatalogForConnection(c.provider, c.authType);
     const r = await enqueueConnectionCommand({
       gatewayId: c.gatewayId,
       action: "auth_set_default",
@@ -328,7 +328,7 @@ export function ConnectionsSettings({
           open
           tone="destructive"
           onCancel={() => setRemoving(null)}
-          title={`Remove ${getProviderCatalog(removing.provider)?.displayName ?? removing.provider}?`}
+          title={`Remove ${getProviderCatalogForConnection(removing.provider, removing.authType)?.displayName ?? removing.provider}?`}
           description={
             <>
               The credential is deleted from this gateway&apos;s auth store.
@@ -358,7 +358,7 @@ function ConnectionRow({
   onRemove: () => void;
   onSetDefault?: () => void;
 }) {
-  const catalog = getProviderCatalog(connection.provider);
+  const catalog = getProviderCatalogForConnection(connection.provider, connection.authType);
   const displayName = catalog?.displayName ?? connection.provider;
   const meta = CONNECTION_STATUS_META[connection.status];
 

--- a/apps/ui/src/lib/connections/parse-status.ts
+++ b/apps/ui/src/lib/connections/parse-status.ts
@@ -15,6 +15,8 @@ interface RawProfile {
   expires?: number;
   expiresAt?: string;
   isDefault?: boolean;
+  /** Credential kind: "oauth" | "api_key" | "token" (openclaw >=6.x). */
+  type?: string;
 }
 
 // Known-bad reasons — anything not listed here is treated as "ok"
@@ -89,6 +91,7 @@ export function parseModelsStatus(
       expiresAt,
       lastCheckedAt: new Date().toISOString(),
       isDefault: !!raw.isDefault,
+      authType: raw.type,
     });
   };
 

--- a/apps/ui/src/lib/connections/types.ts
+++ b/apps/ui/src/lib/connections/types.ts
@@ -40,6 +40,13 @@ export interface Connection {
   lastCheckedAt?: string;
   /** Whether this profile is the gateway's default for new agents. */
   isDefault: boolean;
+  /**
+   * Credential kind as reported by openclaw ("oauth", "api_key", "token").
+   * openclaw >=6.x reports both ChatGPT-OAuth and API-key credentials under
+   * the same provider id ("openai"), so this is the only way to tell the
+   * two flavors apart for display.
+   */
+  authType?: string;
 }
 
 // ─── Provider catalog ────────────────────────────────────────────────
@@ -52,8 +59,16 @@ export interface Connection {
 //     round-trip through the gateway.
 
 export interface ProviderCatalogEntry {
-  /** The string passed to `openclaw --provider`. */
+  /** Catalog identity. Also the `openclaw --provider` value unless gatewayProvider is set. */
   id: string;
+  /**
+   * Provider id the gateway actually uses when it differs from the catalog
+   * id. openclaw >=6.x folded the CLI-specific providers into their base
+   * plugin (openai-codex -> openai, google-gemini-cli -> google); the
+   * catalog keeps separate entries because the auth flows the user picks
+   * between are still distinct.
+   */
+  gatewayProvider?: string;
   displayName: string;
   /** What the user sees when picking. */
   category: "recommended" | "open_models" | "all";
@@ -93,7 +108,8 @@ export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
   },
   {
     id: "openai-codex",
-    displayName: "OpenAI Codex (ChatGPT)",
+    gatewayProvider: "openai",
+    displayName: "OpenAI (ChatGPT)",
     category: "recommended",
     authShape: "oauth_paste",
     alternateShape: "device_code",
@@ -284,6 +300,7 @@ export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
   },
   {
     id: "google-gemini-cli",
+    gatewayProvider: "google",
     displayName: "Gemini CLI",
     category: "all",
     authShape: "oauth_paste",
@@ -294,6 +311,34 @@ export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
 
 export function getProviderCatalog(id: string): ProviderCatalogEntry | undefined {
   return PROVIDER_CATALOG.find((p) => p.id === id);
+}
+
+const OAUTH_SHAPES: AuthShape[] = ["oauth_paste", "device_code", "cli_reuse"];
+
+/**
+ * Resolve the catalog entry for a connection reported by the gateway.
+ *
+ * openclaw >=6.x reports OAuth and API-key credentials under the same
+ * provider id, so when several catalog entries map to the same gateway
+ * provider (openai / openai-codex), the connection's authType picks the
+ * right one for display.
+ */
+export function getProviderCatalogForConnection(
+  provider: string,
+  authType?: string,
+): ProviderCatalogEntry | undefined {
+  const candidates = PROVIDER_CATALOG.filter(
+    (p) => p.id === provider || (p.gatewayProvider ?? p.id) === provider,
+  );
+  if (candidates.length <= 1) return candidates[0];
+  if (authType) {
+    const wantOauth = authType !== "api_key";
+    const match = candidates.find((p) =>
+      wantOauth ? OAUTH_SHAPES.includes(p.authShape) : p.authShape === "api_key",
+    );
+    if (match) return match;
+  }
+  return candidates.find((p) => p.id === provider) ?? candidates[0];
 }
 
 export const CONNECTION_STATUS_META: Record<

--- a/gateway/daemons/command_runner.py
+++ b/gateway/daemons/command_runner.py
@@ -508,8 +508,29 @@ def cleanup_auth_flow(cmd_id, sock=None):
             pass
 
 
+# openclaw >=6.x folded the CLI-specific providers into their base provider
+# plugin (openai-codex -> openai, google-gemini-cli -> google). The UI
+# catalog sends the new names, but normalize here too so an older UI paired
+# with a newer gateway keeps working.
+PROVIDER_ALIASES = {
+    "openai-codex": "openai",
+    "google-gemini-cli": "google",
+}
+
+
+def normalize_provider(provider):
+    return PROVIDER_ALIASES.get(provider, provider)
+
+
+def normalize_model(model):
+    """Normalize the provider segment of a `provider/model` string."""
+    if "/" in model:
+        provider, rest = model.split("/", 1)
+        return f"{normalize_provider(provider)}/{rest}"
+    return model
+
+
 PROVIDER_DEFAULT_MODELS = {
-    "openai-codex": "openai-codex/gpt-5.4",
     "openai": "openai/gpt-5.4",
     "anthropic": "anthropic/claude-sonnet-4-5-20250514",
     "google": "google/gemini-2.5-pro",
@@ -563,12 +584,33 @@ def _set_default_model_for_provider(provider, force=False):
         log(f"Failed to set default model: {e}")
 
 
+def _cleanup_stale_codex_auth(provider):
+    """Drop the codex plugin's cached credentials after an auth change.
+
+    openclaw's codex plugin caches credentials in codex-home/auth.json. When
+    the operator switches auth flavors (api-key -> ChatGPT OAuth or back),
+    the stale cache wins over the new profile and the Codex runtime fails
+    with "network connection error" / invalid_provider_content_type. Remove
+    the cache so the runtime re-derives auth from the new profile.
+    """
+    if provider != "openai":
+        return
+    state_dir = os.environ.get("OPENCLAW_STATE_DIR", os.path.join(HOME, ".openclaw"))
+    path = os.path.join(state_dir, "codex-home", "auth.json")
+    try:
+        if os.path.exists(path):
+            os.remove(path)
+            log(f"Removed stale codex auth cache at {path}")
+    except Exception as e:
+        log(f"Failed to remove stale codex auth cache at {path}: {e}")
+
+
 def handle_auth_set_api_key(cmd_id, payload):
     """Single-shot path for api_key shape — no interactivity required.
 
     payload: { provider: str, api_key: str, profile_name?: str }
     """
-    provider = (payload.get("provider") or "").strip()
+    provider = normalize_provider((payload.get("provider") or "").strip())
     api_key = payload.get("api_key") or ""
     profile_name = (payload.get("profile_name") or "default").strip() or "default"
 
@@ -612,6 +654,7 @@ def handle_auth_set_api_key(cmd_id, payload):
         if proc.returncode != 0:
             raise RuntimeError(f"paste-api-key failed: {(proc.stderr or proc.stdout or '').strip()[:200]}")
 
+        _cleanup_stale_codex_auth(provider)
         _set_default_model_for_provider(provider, force=True)
 
         scrubbed = {k: v for k, v in payload.items() if k not in ("api_key", "base_url")}
@@ -649,7 +692,7 @@ def handle_auth_start(cmd_id, payload):
 
     payload: { provider: str, profile_name?: str, mode?: 'oauth_paste' | 'device_code' }
     """
-    provider = (payload.get("provider") or "").strip()
+    provider = normalize_provider((payload.get("provider") or "").strip())
     profile_name = (payload.get("profile_name") or "default").strip() or "default"
     mode = payload.get("mode") or "oauth_paste"
 
@@ -838,6 +881,7 @@ def handle_auth_start(cmd_id, payload):
 
     if rc == 0:
         profile_id = f"{provider}:{profile_name}"
+        _cleanup_stale_codex_auth(provider)
         sync_to_shared_auth()
         _set_default_model_for_provider(provider, force=True)
         patch_command_payload(
@@ -1121,7 +1165,7 @@ def handle_auth_refresh(cmd_id, payload):
     args = ["openclaw", "models", "status", "--json", "--probe"]
     if profile_id and ":" in profile_id:
         provider, name = profile_id.split(":", 1)
-        args += ["--probe-provider", provider, "--probe-profile", name]
+        args += ["--probe-provider", normalize_provider(provider), "--probe-profile", name]
 
     try:
         result = subprocess.run(
@@ -1163,8 +1207,8 @@ def handle_auth_set_default(cmd_id, payload):
     Tries `openclaw models set-default --provider <id>` first; if that
     subcommand doesn't exist, falls back to `openclaw models set <provider>`.
     """
-    provider = (payload.get("provider") or "").strip()
-    model = (payload.get("model") or "").strip()
+    provider = normalize_provider((payload.get("provider") or "").strip())
+    model = normalize_model((payload.get("model") or "").strip())
     target = provider or model
     if not target:
         api_rpc(

--- a/gateway/daemons/inbox_dispatcher.py
+++ b/gateway/daemons/inbox_dispatcher.py
@@ -147,8 +147,12 @@ def resolve_agent_id(agent_slug):
             aid = entry.get("id") or ""
             if aid.endswith("/" + agent_slug) or aid.endswith("-" + agent_slug):
                 return aid.replace("/", "-")
-    except Exception:
-        pass
+    except Exception as e:
+        print(
+            f"[dispatcher] resolve_agent_id failed for '{agent_slug}' using {OPENCLAW_CONFIG}: {e}; "
+            "falling back to bare slug",
+            file=sys.stderr,
+        )
     return agent_slug
 
 

--- a/gateway/daemons/inbox_dispatcher.py
+++ b/gateway/daemons/inbox_dispatcher.py
@@ -119,7 +119,36 @@ def log(msg, level="info", **extra):
     print(json.dumps(entry, default=str), flush=True)
 
 
+OPENCLAW_CONFIG = os.path.join(
+    os.environ.get("OPENCLAW_HOME", os.path.expanduser("~/.openclaw")),
+    "openclaw.json",
+)
+
+
 def resolve_agent_id(agent_slug):
+    """Map an HQ agent slug to the id openclaw has the agent registered under.
+
+    openclaw >=6.x registers agents as {workspace-slug}/{agent-slug}
+    (add-agent.sh writes that id into agents.list), so waking the bare slug
+    silently targets a nonexistent agent. Look the slug up in openclaw.json
+    and return the registered id with slashes normalized to dashes — the
+    CLI addresses agents in the dash form (`openclaw status` shows
+    prajoth-hq-alex for a config id of prajoth-hq/alex). Fall back to the
+    bare slug if no entry matches (agent not yet provisioned).
+    """
+    try:
+        with open(OPENCLAW_CONFIG) as f:
+            cfg = json.load(f)
+        entries = cfg.get("agents", {}).get("list") or []
+        for entry in entries:
+            if (entry.get("id") or "") == agent_slug:
+                return agent_slug
+        for entry in entries:
+            aid = entry.get("id") or ""
+            if aid.endswith("/" + agent_slug) or aid.endswith("-" + agent_slug):
+                return aid.replace("/", "-")
+    except Exception:
+        pass
     return agent_slug
 
 

--- a/gateway/entrypoint.sh
+++ b/gateway/entrypoint.sh
@@ -22,7 +22,7 @@
 # OAuth login is NOT run automatically — the UI triggers it via the command
 # queue in Phase 3, or you can run it manually:
 #   docker compose exec gateway openclaw models auth login \
-#     --provider openai-codex --set-default
+#     --provider openai --set-default
 # =============================================================================
 set -euo pipefail
 [[ "${DEBUG:-}" == "1" ]] && set -x
@@ -357,6 +357,10 @@ if [ -f "$CONFIG" ]; then
   jq --arg plugin_path "$PLUGIN_DIR" '
     (if .agents.defaults.tools then del(.agents.defaults.tools) else . end) |
     .tools.profile = "full" |
+    # openclaw >=6.x runs tool execution through the Codex sandbox runtime,
+    # gated by tools.codeMode. Without it agents come up in pure chat mode
+    # with zero tools (no exec, no browser, no web_search).
+    .tools.codeMode = true |
     .gateway.bind = "lan" |
     .browser.executablePath //= "/usr/bin/google-chrome-stable" |
     .browser.defaultProfile //= "openclaw" |
@@ -383,6 +387,21 @@ if [ -f "$CONFIG" ]; then
     .plugins.load.paths = ((.plugins.load.paths // []) + [$plugin_path] | unique)
   ' "$CONFIG" > "$TMP" && mv "$TMP" "$CONFIG"
 fi
+
+# openclaw >=6.x ships provider integrations as installable plugins instead
+# of bundling them. Without the provider plugin, `openclaw models auth`
+# fails and agents can't resolve their model. Install into ~/.openclaw
+# (a volume, so this must happen at boot, not image build). Idempotent —
+# skip anything already installed. Extend via OPENCLAW_PROVIDER_PLUGINS.
+PROVIDER_PLUGINS="${OPENCLAW_PROVIDER_PLUGINS:-openai}"
+INSTALLED_PLUGINS=$(openclaw plugins list 2>/dev/null || true)
+for p in $PROVIDER_PLUGINS; do
+  if ! printf '%s' "$INSTALLED_PLUGINS" | grep -q "$p"; then
+    log "Installing provider plugin: $p ..."
+    openclaw plugins install "$p" \
+      || log "  ⚠ failed to install provider plugin $p — model auth for it will not work"
+  fi
+done
 
 if [ -d "$PLUGIN_SRC" ]; then
   mkdir -p "$PLUGIN_DIR"
@@ -731,7 +750,10 @@ if [ "$RUNTIME_MODE" = "hosted" ]; then
   [ -d "$DAEMON_DIR" ] || DAEMON_DIR="$(dirname "$(readlink -f "$0")")/daemons"
 
   if [ -f "$DAEMON_DIR/embedder.py" ] && [ -z "${EMBEDDER_URL:-}" ]; then
-    export EMBEDDER_URL="http://localhost:18801"
+    # Use port 9100 in hosted mode — 18801 is the first CDP port allocated
+    # by add-agent.sh and would collide with the first agent's Chrome.
+    export EMBEDDER_PORT="${EMBEDDER_PORT:-9100}"
+    export EMBEDDER_URL="http://localhost:${EMBEDDER_PORT}"
   fi
 
   if [ -f "$DAEMON_DIR/embedder.py" ]; then

--- a/gateway/tests/test_command_runner.py
+++ b/gateway/tests/test_command_runner.py
@@ -577,7 +577,8 @@ def test_auth_set_default_uses_models_set(monkeypatch):
     cr.handle_auth_set_default("cmd-sd-1", {"provider": "openai-codex"})
 
     assert len(runs) == 1
-    assert runs[0] == ["openclaw", "models", "set", "openai-codex"]
+    # openclaw >=6.x folded openai-codex into openai; the runner normalizes.
+    assert runs[0] == ["openclaw", "models", "set", "openai"]
     assert "set-default" not in runs[0]
     assert any(fn == "complete_command" for fn, _ in rpc_calls)
 
@@ -642,3 +643,75 @@ def test_auth_set_api_key_uses_paste_api_key_cli(monkeypatch):
     assert "--agent" not in paste[0]  # paste-api-key has no --agent flag in 5.28
     assert "sk-test\n" in stdins  # key delivered via stdin, not argv
     assert any(fn == "complete_command" for fn, _ in rpc_calls)
+
+
+# ── provider normalization (openclaw >=6.x renames) ────────────────────
+
+
+def test_normalize_provider_maps_openai_codex():
+    import command_runner as mod
+
+    assert mod.normalize_provider("openai-codex") == "openai"
+
+
+def test_normalize_provider_maps_google_gemini_cli():
+    import command_runner as mod
+
+    assert mod.normalize_provider("google-gemini-cli") == "google"
+
+
+def test_normalize_provider_passes_through_unmapped():
+    import command_runner as mod
+
+    assert mod.normalize_provider("anthropic") == "anthropic"
+    assert mod.normalize_provider("openai") == "openai"
+
+
+def test_normalize_model_rewrites_provider_segment():
+    import command_runner as mod
+
+    assert mod.normalize_model("openai-codex/gpt-5.4") == "openai/gpt-5.4"
+    assert mod.normalize_model("anthropic/claude-sonnet-4-5") == "anthropic/claude-sonnet-4-5"
+
+
+def test_normalize_model_leaves_bare_names():
+    import command_runner as mod
+
+    assert mod.normalize_model("gpt-5.4") == "gpt-5.4"
+    assert mod.normalize_model("") == ""
+
+
+# ── codex auth cache cleanup ───────────────────────────────────────────
+
+
+def test_cleanup_stale_codex_auth_removes_cache(tmp_path, monkeypatch):
+    import command_runner as mod
+
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    auth = codex_home / "auth.json"
+    auth.write_text("{}")
+    monkeypatch.setenv("OPENCLAW_STATE_DIR", str(tmp_path))
+
+    mod._cleanup_stale_codex_auth("openai")
+    assert not auth.exists()
+
+
+def test_cleanup_stale_codex_auth_ignores_other_providers(tmp_path, monkeypatch):
+    import command_runner as mod
+
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    auth = codex_home / "auth.json"
+    auth.write_text("{}")
+    monkeypatch.setenv("OPENCLAW_STATE_DIR", str(tmp_path))
+
+    mod._cleanup_stale_codex_auth("anthropic")
+    assert auth.exists()
+
+
+def test_cleanup_stale_codex_auth_noop_when_absent(tmp_path, monkeypatch):
+    import command_runner as mod
+
+    monkeypatch.setenv("OPENCLAW_STATE_DIR", str(tmp_path))
+    mod._cleanup_stale_codex_auth("openai")  # must not raise

--- a/gateway/tests/test_inbox_dispatcher.py
+++ b/gateway/tests/test_inbox_dispatcher.py
@@ -1,3 +1,4 @@
+import json
 import subprocess
 
 import pytest
@@ -473,3 +474,54 @@ def test_inbox_dispatcher_ws_url(monkeypatch):
     url = dispatcher._ws_url()
     assert url.startswith("wss://abc.supabase.co")
     assert "apikey=my-key" in url
+
+
+# ── resolve_agent_id (openclaw >=6.x workspace-prefixed ids) ───────────
+
+
+def _write_openclaw_config(tmp_path, agent_ids):
+    cfg = {"agents": {"list": [{"id": aid} for aid in agent_ids]}}
+    path = tmp_path / "openclaw.json"
+    path.write_text(json.dumps(cfg))
+    return str(path)
+
+
+def test_resolve_agent_id_normalizes_slash_id_to_dash_form(tmp_path, monkeypatch):
+    import inbox_dispatcher as mod
+
+    path = _write_openclaw_config(tmp_path, ["prajoth-hq/alex"])
+    monkeypatch.setattr(mod, "OPENCLAW_CONFIG", path)
+    # Config registers the slash form, but the CLI addresses agents with
+    # dashes -- the wake call must use the dash form.
+    assert mod.resolve_agent_id("alex") == "prajoth-hq-alex"
+
+
+def test_resolve_agent_id_returns_registered_dash_id(tmp_path, monkeypatch):
+    import inbox_dispatcher as mod
+
+    path = _write_openclaw_config(tmp_path, ["prajoth-hq-alex"])
+    monkeypatch.setattr(mod, "OPENCLAW_CONFIG", path)
+    assert mod.resolve_agent_id("alex") == "prajoth-hq-alex"
+
+
+def test_resolve_agent_id_prefers_exact_match(tmp_path, monkeypatch):
+    import inbox_dispatcher as mod
+
+    path = _write_openclaw_config(tmp_path, ["ws-alex", "alex"])
+    monkeypatch.setattr(mod, "OPENCLAW_CONFIG", path)
+    assert mod.resolve_agent_id("alex") == "alex"
+
+
+def test_resolve_agent_id_falls_back_to_slug_when_unregistered(tmp_path, monkeypatch):
+    import inbox_dispatcher as mod
+
+    path = _write_openclaw_config(tmp_path, ["prajoth-hq/alex"])
+    monkeypatch.setattr(mod, "OPENCLAW_CONFIG", path)
+    assert mod.resolve_agent_id("mary") == "mary"
+
+
+def test_resolve_agent_id_falls_back_when_config_missing(monkeypatch):
+    import inbox_dispatcher as mod
+
+    monkeypatch.setattr(mod, "OPENCLAW_CONFIG", "/nonexistent/openclaw.json")
+    assert mod.resolve_agent_id("alex") == "alex"


### PR DESCRIPTION
## Summary

Fixes every v6.1 compatibility issue found while auditing a live E2B gateway after the v0.2.0 / openclaw 6.1 upgrade. Without these, fresh gateway spawns come up with tool-less agents, no provider auth, and a dead Live Browser.

### Gateway (entrypoint)
- **Set `tools.codeMode: true`** in the config patch — openclaw 6.x runs tool execution through the Codex sandbox runtime; without this agents are pure chat with zero tools (no exec, browser, or web_search). The single most critical 6.1 change.
- **Install provider plugins at boot** — 6.x no longer bundles providers; `openclaw models auth` fails without the plugin. Installs `$OPENCLAW_PROVIDER_PLUGINS` (default `openai`) idempotently. Boot-time rather than image build because `~/.openclaw` is a volume.
- **Move hosted-mode embedder to port 9100** — it defaulted to 18801, which is the first CDP port `add-agent.sh` allocates for an agent's Chrome. The embedder grabbed it first, Chrome could never start, and the Live Browser tab showed "Chrome is not reachable". Docker mode unaffected (separate container).

### Daemons
- **command_runner**: normalize renamed providers (`openai-codex` → `openai`, `google-gemini-cli` → `google`) across all four auth handlers, including the provider segment of model ids.
- **command_runner**: delete stale `codex-home/auth.json` after a successful openai auth change — the codex plugin's cached API-key auth otherwise wins over a new OAuth login and fails with `invalid_provider_content_type`.
- **inbox_dispatcher**: resolve agent wakes through `openclaw.json` `agents.list` — 6.x registers agents as `{workspace-slug}/{agent-slug}` and the CLI addresses them in dash form (`prajoth-hq-alex`); waking the bare slug silently targets a nonexistent agent.

### Connections UI
- Capture the credential `type` field from `models status` into `Connection.authType`.
- New `getProviderCatalogForConnection(provider, authType)` picks the right catalog entry when one gateway provider id backs multiple auth flavors — a ChatGPT OAuth connection now shows "OpenAI (ChatGPT)" instead of "OpenAI (API key)".
- Catalog entries for `openai-codex` / `google-gemini-cli` carry a `gatewayProvider` mapping to the 6.1 provider ids.

## Testing
- 280 gateway Python tests pass (new coverage: provider normalization, codex cache cleanup, `resolve_agent_id` dash/slash/exact/fallback cases)
- 2,409 UI tests pass across 200 files (new coverage: `authType` parsing, catalog resolution)
- `tsc --noEmit` clean; `bash -n` on entrypoint
- All fixes were first verified live on an E2B sandbox running openclaw 2026.6.1 before being ported here

🤖 Generated with [Claude Code](https://claude.com/claude-code)