### PR TITLE
Gateway hardening: OpenClaw 6.6 + backup/restore + critical fixes

### DIFF
--- a/.github/workflows/e2b-template.yml
+++ b/.github/workflows/e2b-template.yml
@@ -1,12 +1,10 @@
 name: Build E2B gateway template
 
 # Runs AFTER "Publish images" finishes, never in parallel with it.
-# The template's Dockerfile.e2b does `FROM ghcr.io/yourhq/yourhq-gateway:latest`,
-# so the gateway base image must already be republished before this builds —
-# otherwise the template ends up FROM a stale base (this once shipped a
-# template running an old OpenClaw despite a correct base build). Triggering
-# on workflow_run guarantees the ordering; build-template.mjs uses skipCache()
-# so the base layer is always re-pulled fresh.
+# build-template.mjs resolves the semver tag from git (v0.2.0 → 0.2.0) and
+# injects it into Dockerfile.e2b's GATEWAY_TAG arg so the E2B template is
+# pinned to the exact release. skipCache() ensures the base layer is always
+# re-pulled fresh.
 on:
   workflow_run:
     workflows: ["Publish images"]
@@ -44,7 +42,16 @@ jobs:
       - name: Install E2B SDK
         run: npm install e2b
 
+      - name: Resolve gateway image tag
+        id: tag
+        run: |
+          # Strip 'v' prefix from the git tag (v0.2.0 → 0.2.0) to match
+          # the semver image tags published by docker-publish.yml.
+          RAW=$(git describe --tags --abbrev=0 2>/dev/null || echo "latest")
+          echo "gateway_tag=${RAW#v}" >> "$GITHUB_OUTPUT"
+
       - name: Build and push template
         env:
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+          GATEWAY_TAG: ${{ steps.tag.outputs.gateway_tag }}
         run: node gateway/build-template.mjs

--- a/apps/ui/src/app/dashboard/settings/backups/actions.ts
+++ b/apps/ui/src/app/dashboard/settings/backups/actions.ts
@@ -3,7 +3,6 @@
 import { createAdminClient } from "@/lib/supabase/admin";
 import { requireAuth } from "@/lib/supabase/require-auth";
 import { enqueueAgentCommand } from "@/app/dashboard/agents/actions";
-import type { Gateway } from "@/lib/gateways/types";
 
 export interface BackupInfo {
   gatewayId: string;

--- a/apps/ui/src/app/dashboard/settings/backups/actions.ts
+++ b/apps/ui/src/app/dashboard/settings/backups/actions.ts
@@ -1,0 +1,80 @@
+"use server";
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import { requireAuth } from "@/lib/supabase/require-auth";
+import { enqueueAgentCommand } from "@/app/dashboard/agents/actions";
+import type { Gateway } from "@/lib/gateways/types";
+
+export interface BackupInfo {
+  gatewayId: string;
+  gatewaySlug: string;
+  gatewayLabel: string;
+  gatewayStatus: string;
+  lastBackupAt: string | null;
+  lastBackupSizeBytes: number | null;
+  lastSeenAt: string | null;
+}
+
+export interface BackupActionResult<T = void> {
+  ok: boolean;
+  error?: string;
+  data?: T;
+}
+
+export async function listGatewayBackupsAction(): Promise<
+  BackupActionResult<BackupInfo[]>
+> {
+  await requireAuth();
+  const supabase = await createAdminClient();
+  const { data, error } = await supabase
+    .from("gateways")
+    .select("id, slug, label, status, last_seen_at, last_backup_at, last_backup_size_bytes")
+    .order("created_at", { ascending: true });
+
+  if (error) return { ok: false, error: error.message };
+
+  const backups: BackupInfo[] = (data ?? []).map((gw: Record<string, unknown>) => ({
+    gatewayId: gw.id as string,
+    gatewaySlug: gw.slug as string,
+    gatewayLabel: gw.label as string,
+    gatewayStatus: gw.status as string,
+    lastBackupAt: (gw.last_backup_at as string) ?? null,
+    lastBackupSizeBytes: (gw.last_backup_size_bytes as number) ?? null,
+    lastSeenAt: (gw.last_seen_at as string) ?? null,
+  }));
+
+  return { ok: true, data: backups };
+}
+
+export async function triggerBackupAction(
+  gatewayId: string,
+): Promise<BackupActionResult<{ commandId: string }>> {
+  await requireAuth();
+  const result = await enqueueAgentCommand({
+    action: "backup_gateway",
+    gatewayId,
+  });
+  return { ok: true, data: { commandId: result.commandId } };
+}
+
+export async function deleteBackupAction(
+  gatewaySlug: string,
+): Promise<BackupActionResult> {
+  await requireAuth();
+  const supabase = await createAdminClient();
+
+  const { error: storageError } = await supabase.storage
+    .from("gateway-backups")
+    .remove([`${gatewaySlug}/state.tar.gz`]);
+
+  if (storageError) return { ok: false, error: storageError.message };
+
+  const { error: updateError } = await supabase
+    .from("gateways")
+    .update({ last_backup_at: null, last_backup_size_bytes: null })
+    .eq("slug", gatewaySlug);
+
+  if (updateError) return { ok: false, error: updateError.message };
+
+  return { ok: true };
+}

--- a/apps/ui/src/app/dashboard/settings/backups/page.tsx
+++ b/apps/ui/src/app/dashboard/settings/backups/page.tsx
@@ -1,0 +1,9 @@
+import { listGatewayBackupsAction } from "./actions";
+import { BackupsSettings } from "@/components/backups/backups-settings";
+
+export const dynamic = "force-dynamic";
+
+export default async function BackupsSettingsPage() {
+  const r = await listGatewayBackupsAction();
+  return <BackupsSettings initialBackups={r.ok ? (r.data ?? []) : []} />;
+}

--- a/apps/ui/src/app/dashboard/settings/settings-shell.tsx
+++ b/apps/ui/src/app/dashboard/settings/settings-shell.tsx
@@ -23,6 +23,7 @@ import {
   Settings,
   Tag,
   LayoutTemplate,
+  HardDrive,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -94,6 +95,7 @@ const SETTINGS_NAV: NavGroup[] = [
       { href: "/dashboard/settings/secrets", label: "Secrets", icon: Lock },
       { href: "/dashboard/settings/budgets", label: "Budget Defaults", icon: DollarSign },
       { href: "/dashboard/settings/plugins", label: "Plugins", icon: Blocks },
+      { href: "/dashboard/settings/backups", label: "Backups", icon: HardDrive },
     ],
   },
   {

--- a/apps/ui/src/components/backups/backups-settings.tsx
+++ b/apps/ui/src/components/backups/backups-settings.tsx
@@ -225,8 +225,9 @@ function GatewayBackupRow({
   onBackup: () => void;
   onDelete: () => void;
 }) {
+  const [now] = useState(() => globalThis.Date.now());
   const isOnline = info.gatewayStatus === "ready" && info.lastSeenAt &&
-    Date.now() - new Date(info.lastSeenAt).getTime() < 90_000;
+    now - new Date(info.lastSeenAt).getTime() < 90_000;
 
   return (
     <div

--- a/apps/ui/src/components/backups/backups-settings.tsx
+++ b/apps/ui/src/components/backups/backups-settings.tsx
@@ -1,0 +1,298 @@
+"use client";
+
+import { useState } from "react";
+import {
+  HardDrive,
+  Download,
+  Trash2,
+  RefreshCw,
+  Shield,
+  Clock,
+  Server,
+  Loader2,
+} from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+import { toast } from "sonner";
+import { PageHeader, PageSection } from "@/components/shared/page-header";
+import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/shared/confirm-dialog";
+import { EmptyState } from "@/components/shared/empty-state";
+import { useRealtime } from "@/hooks/use-realtime";
+import {
+  listGatewayBackupsAction,
+  triggerBackupAction,
+  deleteBackupAction,
+  type BackupInfo,
+} from "@/app/dashboard/settings/backups/actions";
+import { cn } from "@/lib/utils";
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+interface BackupsSettingsProps {
+  initialBackups: BackupInfo[];
+}
+
+export function BackupsSettings({ initialBackups }: BackupsSettingsProps) {
+  const [backups, setBackups] = useState<BackupInfo[]>(initialBackups);
+  const [backingUp, setBackingUp] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState<BackupInfo | null>(null);
+
+  const refetch = async () => {
+    const r = await listGatewayBackupsAction();
+    if (r.ok && r.data) setBackups(r.data);
+  };
+
+  useRealtime({
+    table: "gateways",
+    onPayload: () => void refetch(),
+  });
+
+  const handleBackup = async (gatewayId: string) => {
+    setBackingUp(gatewayId);
+    try {
+      await triggerBackupAction(gatewayId);
+      toast.success("Backup started — this may take a few seconds.");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to start backup");
+    } finally {
+      setTimeout(() => setBackingUp(null), 3000);
+    }
+  };
+
+  const handleDelete = async (info: BackupInfo) => {
+    try {
+      const r = await deleteBackupAction(info.gatewaySlug);
+      if (!r.ok) {
+        toast.error(r.error ?? "Failed to delete backup");
+        return;
+      }
+      toast.success("Backup deleted");
+      await refetch();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to delete backup");
+    }
+    setDeleting(null);
+  };
+
+  const hasAnyBackup = backups.some((b) => b.lastBackupAt);
+
+  return (
+    <div className="flex h-full flex-col">
+      <PageHeader
+        icon={<HardDrive className="h-4 w-4" />}
+        title="Backups"
+        description="Gateway state backups protect your agent auth tokens, configs, and secrets. Backups are created automatically on shutdown and can be triggered manually."
+      />
+
+      <div className="flex-1 overflow-auto">
+        <div className="mx-auto w-full max-w-2xl px-5 py-5 space-y-6">
+          {/* How it works */}
+          <PageSection
+            title="How backups work"
+            description="Each gateway's state is backed up to Supabase Storage as a compressed archive."
+          >
+            <div className="grid gap-3 sm:grid-cols-3">
+              <InfoCard
+                icon={Shield}
+                title="Automatic"
+                description="Backups run on gateway shutdown (SIGTERM) so state is captured before the process exits."
+              />
+              <InfoCard
+                icon={Clock}
+                title="Restore on boot"
+                description="When a gateway starts fresh with no local state, it restores from the newest backup — if corrupt, it tries the next."
+              />
+              <InfoCard
+                icon={Download}
+                title="On-demand"
+                description="Trigger a backup anytime from this page. Useful before maintenance or risky changes."
+              />
+            </div>
+          </PageSection>
+
+          {/* Gateway backup list */}
+          <PageSection title="Gateways">
+            {backups.length === 0 ? (
+              <EmptyState
+                icon={Server}
+                title="No gateways"
+                description="Add a gateway first — backups will appear here automatically."
+              />
+            ) : (
+              <div className="overflow-hidden rounded-md border border-border/60 bg-card">
+                {backups.map((info, idx) => (
+                  <GatewayBackupRow
+                    key={info.gatewayId}
+                    info={info}
+                    isFirst={idx === 0}
+                    isBackingUp={backingUp === info.gatewayId}
+                    onBackup={() => handleBackup(info.gatewayId)}
+                    onDelete={() => setDeleting(info)}
+                  />
+                ))}
+              </div>
+            )}
+          </PageSection>
+
+          {/* Backup contents explanation */}
+          {hasAnyBackup && (
+            <PageSection title="What's included">
+              <div className="rounded-md border border-border/40 bg-muted/20 p-4 text-[13px] text-muted-foreground space-y-2">
+                <div className="flex items-start gap-2">
+                  <span className="mt-0.5 h-1.5 w-1.5 shrink-0 rounded-full bg-status-success" />
+                  <span>Auth stores (OAuth tokens, API keys) — so you never need to reauth</span>
+                </div>
+                <div className="flex items-start gap-2">
+                  <span className="mt-0.5 h-1.5 w-1.5 shrink-0 rounded-full bg-status-success" />
+                  <span>Agent configs (openclaw.json, per-agent settings)</span>
+                </div>
+                <div className="flex items-start gap-2">
+                  <span className="mt-0.5 h-1.5 w-1.5 shrink-0 rounded-full bg-status-success" />
+                  <span>Secrets and shared-auth files</span>
+                </div>
+                <div className="flex items-start gap-2">
+                  <span className="mt-0.5 h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/40" />
+                  <span>Excluded: browser profiles, npm cache, git repo, logs (rebuilt on boot)</span>
+                </div>
+                <div className="mt-3 border-t border-border/30 pt-3 text-[12px] text-muted-foreground/70">
+                  Retention: last 3 backups per gateway, auto-pruned after 7 days.
+                  Restore tries newest first and falls back if corrupt.
+                </div>
+              </div>
+            </PageSection>
+          )}
+        </div>
+      </div>
+
+      {deleting && (
+        <ConfirmDialog
+          open
+          tone="destructive"
+          onCancel={() => setDeleting(null)}
+          title={`Delete backup for ${deleting.gatewayLabel}?`}
+          description={
+            <>
+              This removes the stored backup for{" "}
+              <span className="font-mono">{deleting.gatewaySlug}</span>. The
+              gateway will start fresh if it needs to be recreated. A new
+              backup will be created on the next shutdown.
+            </>
+          }
+          confirmLabel="Delete backup"
+          onConfirm={() => handleDelete(deleting)}
+        />
+      )}
+    </div>
+  );
+}
+
+function InfoCard({
+  icon: Icon,
+  title,
+  description,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="rounded-md border border-border/40 bg-muted/20 p-3.5">
+      <div className="mb-2 flex h-7 w-7 items-center justify-center rounded bg-primary/10 text-primary">
+        <Icon className="h-3.5 w-3.5" />
+      </div>
+      <div className="text-[13px] font-medium text-foreground">{title}</div>
+      <div className="mt-0.5 text-[12px] leading-relaxed text-muted-foreground">
+        {description}
+      </div>
+    </div>
+  );
+}
+
+function GatewayBackupRow({
+  info,
+  isFirst,
+  isBackingUp,
+  onBackup,
+  onDelete,
+}: {
+  info: BackupInfo;
+  isFirst: boolean;
+  isBackingUp: boolean;
+  onBackup: () => void;
+  onDelete: () => void;
+}) {
+  const isOnline = info.gatewayStatus === "ready" && info.lastSeenAt &&
+    Date.now() - new Date(info.lastSeenAt).getTime() < 90_000;
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 px-4 py-3",
+        !isFirst && "border-t border-border/50",
+      )}
+    >
+      {/* Gateway info */}
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded bg-muted/40 text-muted-foreground">
+        <Server className="h-4 w-4" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="text-[13px] font-medium text-foreground">
+            {info.gatewayLabel}
+          </span>
+          <span className="font-mono text-[11px] text-muted-foreground/60">
+            {info.gatewaySlug}
+          </span>
+        </div>
+        <div className="mt-0.5 text-[12px] text-muted-foreground">
+          {info.lastBackupAt ? (
+            <>
+              Last backup{" "}
+              {formatDistanceToNow(new Date(info.lastBackupAt), {
+                addSuffix: true,
+              })}
+              {info.lastBackupSizeBytes != null && (
+                <> · {formatBytes(info.lastBackupSizeBytes)}</>
+              )}
+            </>
+          ) : (
+            <span className="text-muted-foreground/50">No backup yet</span>
+          )}
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="flex shrink-0 items-center gap-1.5">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onBackup}
+          disabled={isBackingUp || !isOnline}
+          title={!isOnline ? "Gateway must be online to back up" : "Create backup now"}
+        >
+          {isBackingUp ? (
+            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+          )}
+          {isBackingUp ? "Backing up..." : "Back up now"}
+        </Button>
+        {info.lastBackupAt && (
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={onDelete}
+            title="Delete backup"
+            className="text-muted-foreground hover:text-destructive"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/workspaces/workspace-switcher.tsx
+++ b/apps/ui/src/components/workspaces/workspace-switcher.tsx
@@ -37,7 +37,15 @@ async function switchWorkspace(workspaceId: string) {
     console.error("Workspace switch failed", await res.text());
     return;
   }
-  window.location.reload();
+  // Navigate to the section root instead of reloading the current URL.
+  // e.g. /dashboard/agents/sierra → /dashboard/agents
+  // This avoids 404s when the new workspace doesn't have the same resource.
+  const segments = window.location.pathname.split("/").filter(Boolean);
+  const sectionRoot =
+    segments.length > 2
+      ? "/" + segments.slice(0, 2).join("/")
+      : window.location.pathname;
+  window.location.href = sectionRoot;
 }
 
 export function WorkspaceSwitcher({

--- a/apps/ui/src/lib/agents/types.ts
+++ b/apps/ui/src/lib/agents/types.ts
@@ -103,7 +103,8 @@ export type CommandAction =
   | "collection_list"
   | "collection_query"
   | "collection_record_create"
-  | "collection_record_update";
+  | "collection_record_update"
+  | "backup_gateway";
 
 export type CommandStatus = "pending" | "leased" | "running" | "done" | "failed";
 
@@ -134,7 +135,7 @@ export const AGENT_COMMAND_ACTIONS: CommandAction[] = [
 ];
 
 export const SYSTEM_COMMAND_ACTIONS: CommandAction[] = [
-  "restart_gateway", "update_all", "restart_dispatcher", "update_gateway",
+  "restart_gateway", "update_all", "restart_dispatcher", "update_gateway", "backup_gateway",
 ];
 
 export const CONNECTION_COMMAND_ACTIONS: CommandAction[] = [
@@ -168,6 +169,7 @@ export const COMMAND_ACTION_LABELS: Record<CommandAction, string> = {
   collection_query: "Query collection",
   collection_record_create: "Create record",
   collection_record_update: "Update record",
+  backup_gateway: "Backup Gateway",
 };
 
 export const COMMAND_STATUS_COLORS: Record<CommandStatus, string> = {

--- a/apps/ui/src/lib/gateways/types.ts
+++ b/apps/ui/src/lib/gateways/types.ts
@@ -38,6 +38,8 @@ export interface Gateway {
   label: string;
   status: GatewayStatus;
   last_seen_at: string | null;
+  last_backup_at: string | null;
+  last_backup_size_bytes: number | null;
   created_at: string;
   updated_at: string;
   meta: GatewayMeta;

--- a/db/migrations/038_gateway_backups.sql
+++ b/db/migrations/038_gateway_backups.sql
@@ -1,0 +1,32 @@
+-- 038_gateway_backups.sql — Storage bucket + metadata for gateway state backups.
+
+-- ── Storage bucket ────────────────────────────────────────────────
+
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('gateway-backups', 'gateway-backups', false)
+ON CONFLICT (id) DO NOTHING;
+
+-- Only service_role can access backups (gateways use the service role key).
+-- The global service_role policy from 017 already covers this, but we add
+-- an explicit one scoped to this bucket for clarity.
+DROP POLICY IF EXISTS "Gateway backup service access" ON storage.objects;
+CREATE POLICY "Gateway backup service access" ON storage.objects
+  FOR ALL TO service_role
+  USING (bucket_id = 'gateway-backups')
+  WITH CHECK (bucket_id = 'gateway-backups');
+
+-- ── Backup metadata on gateways table ─────────────────────────────
+-- Track last backup time and size so the UI can display backup status
+-- without listing storage objects.
+
+ALTER TABLE gateways
+  ADD COLUMN IF NOT EXISTS last_backup_at timestamptz,
+  ADD COLUMN IF NOT EXISTS last_backup_size_bytes bigint;
+
+GRANT SELECT, INSERT, UPDATE ON gateways TO authenticated;
+GRANT ALL ON gateways TO service_role;
+
+-- ── command_action enum extension ─────────────────────────────────
+-- Add backup_gateway to the allowed actions. The enum lives as a CHECK
+-- constraint on agent_commands.action — we need to update it.
+-- (The column is text with no enum type, so no ALTER TYPE needed.)

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -23,7 +23,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     LC_ALL=C.UTF-8 \
     DISPLAY=:1 \
     HOME=/home/openclaw \
-    OPENCLAW_VERSION=v2026.6.1 \
+    OPENCLAW_VERSION=v2026.6.6 \
     NOVNC_VERSION=1.5.0 \
     TARGETARCH=amd64
 

--- a/gateway/Dockerfile.e2b
+++ b/gateway/Dockerfile.e2b
@@ -1,4 +1,5 @@
-FROM ghcr.io/yourhq/yourhq-gateway:latest
+ARG GATEWAY_TAG=latest
+FROM ghcr.io/yourhq/yourhq-gateway:${GATEWAY_TAG}
 
 USER root
 

--- a/gateway/build-template.mjs
+++ b/gateway/build-template.mjs
@@ -1,16 +1,29 @@
 import { Template, defaultBuildLogger } from "e2b";
-import { readFileSync } from "node:fs";
+import { readFileSync, existsSync } from "node:fs";
+import { execSync } from "node:child_process";
+
+// Resolve the gateway image tag from the git tag (v0.2.0 → 0.2.0) so the
+// E2B template is pinned to the exact release that was just published.
+let gatewayTag = process.env.GATEWAY_TAG || "";
+if (!gatewayTag) {
+  try {
+    const raw = execSync("git describe --tags --abbrev=0", { encoding: "utf-8" }).trim();
+    gatewayTag = raw.replace(/^v/, "");
+  } catch {
+    gatewayTag = "latest";
+  }
+}
+console.log(`[e2b] Using gateway base image tag: ${gatewayTag}`);
 
 console.log("[e2b] Reading gateway/Dockerfile.e2b...");
-const dockerfile = readFileSync("gateway/Dockerfile.e2b", "utf-8");
+let dockerfile = readFileSync("gateway/Dockerfile.e2b", "utf-8");
+dockerfile = dockerfile.replace(/^ARG GATEWAY_TAG=.*$/m, `ARG GATEWAY_TAG=${gatewayTag}`);
 console.log(`[e2b] Dockerfile loaded (${dockerfile.split("\n").length} lines)`);
 
 console.log("[e2b] Parsing Dockerfile into template definition...");
-// skipCache: Dockerfile.e2b does `FROM ghcr.io/yourhq/yourhq-gateway:latest`.
-// E2B caches the FROM layer by tag string, not digest — so after a release
-// republishes :latest, a cached build silently reuses the OLD base image
-// (this shipped a stale gateway once). Skip cache so the base is always
-// re-pulled fresh. Releases are infrequent; correctness > a few minutes.
+// skipCache: E2B caches the FROM layer by tag string, not digest — so after
+// a release republishes a tag, a cached build silently reuses the OLD base
+// image. Skip cache so the base is always re-pulled fresh.
 const template = Template({ fileContextPath: "." }).skipCache().fromDockerfile(dockerfile);
 console.log("[e2b] Template definition ready");
 

--- a/gateway/daemons/command_runner.py
+++ b/gateway/daemons/command_runner.py
@@ -91,7 +91,28 @@ COMPOSE_PROJECT = os.environ.get("COMPOSE_PROJECT", "yourhq")
 
 # This gateway's identity. Used to filter lease_command calls so multiple
 # gateways running against the same Supabase don't steal each other's work.
-GATEWAY_ID = os.environ.get("GATEWAY_ID", "default")
+# Prefer the process env, but fall back to gateway.env (which the entrypoint
+# persists after slug resolution) so daemons restarted outside the entrypoint
+# still pick up the correct ID.
+def _resolve_gateway_id():
+    gid = os.environ.get("GATEWAY_ID")
+    if gid and gid != "default":
+        return gid
+    _gw_env = os.path.join(
+        os.environ.get("OPENCLAW_STATE_DIR", os.path.join(HOME, ".openclaw")),
+        "secrets", "gateway.env",
+    )
+    if os.path.isfile(_gw_env):
+        with open(_gw_env) as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith("GATEWAY_ID="):
+                    val = line.split("=", 1)[1].strip("'\"")
+                    if val:
+                        return val
+    return gid or "default"
+
+GATEWAY_ID = _resolve_gateway_id()
 GATEWAY_LABEL = os.environ.get("GATEWAY_LABEL", GATEWAY_ID)
 
 DEFAULT_TENANT_ID = "00000000-0000-0000-0000-000000000000"
@@ -1280,15 +1301,116 @@ def handle_auth_set_default(cmd_id, payload):
         )
 
 
-def sync_to_shared_auth():
-    """Copy the latest auth-profiles.json into shared-auth and propagate to all
-    agent directories so every agent (existing and future) has credentials."""
+def _sync_sqlite_auth():
+    """Clone the SQLite auth store from the source agent to all others.
+
+    OpenClaw ≥6.6 stores auth in per-agent SQLite databases at
+    agents/<id>/agent/openclaw-agent.sqlite. The schema_meta table has an
+    agent_id field that must match the owning agent's directory name.
+
+    Returns True if SQLite auth was found and synced, False otherwise.
+    """
+    import glob as _glob
+    import shutil
+    import sqlite3
+
+    state_dir = os.environ.get("OPENCLAW_STATE_DIR", os.path.join(HOME, ".openclaw"))
+    agent_dirs = _glob.glob(os.path.join(state_dir, "agents", "*", "agent"))
+    if not agent_dirs:
+        return False
+
+    SQLITE_NAME = "openclaw-agent.sqlite"
+
+    # Find the best source: most recently modified SQLite with actual auth data.
+    best_src = None
+    best_mtime = 0
+    for d in agent_dirs:
+        db_path = os.path.join(d, SQLITE_NAME)
+        if not os.path.isfile(db_path):
+            continue
+        try:
+            mt = os.path.getmtime(db_path)
+        except OSError:
+            continue
+        if mt <= best_mtime:
+            continue
+        try:
+            conn = sqlite3.connect(db_path)
+            row = conn.execute(
+                "SELECT store_json FROM auth_profile_store LIMIT 1"
+            ).fetchone()
+            conn.close()
+            if row and len(row[0]) > 10:
+                best_src = db_path
+                best_mtime = mt
+        except Exception:
+            continue
+
+    if not best_src:
+        return False
+
+    cloned = 0
+    for d in agent_dirs:
+        dest = os.path.join(d, SQLITE_NAME)
+        if os.path.realpath(dest) == os.path.realpath(best_src):
+            continue
+
+        agent_name = os.path.basename(os.path.dirname(d))
+
+        # Skip if dest already has valid auth (don't overwrite a working store).
+        if os.path.isfile(dest):
+            try:
+                conn = sqlite3.connect(dest)
+                row = conn.execute(
+                    "SELECT store_json FROM auth_profile_store LIMIT 1"
+                ).fetchone()
+                aid = conn.execute(
+                    "SELECT agent_id FROM schema_meta WHERE meta_key = 'primary'"
+                ).fetchone()
+                conn.close()
+                if row and len(row[0]) > 10 and aid and aid[0] == agent_name:
+                    continue
+            except Exception:
+                pass
+
+        # Copy and patch agent_id.
+        try:
+            for ext in ("", "-wal", "-shm", "-journal"):
+                stale = dest + ext
+                if os.path.exists(stale):
+                    os.remove(stale)
+            shutil.copy2(best_src, dest)
+            conn = sqlite3.connect(dest)
+            conn.execute(
+                "UPDATE schema_meta SET agent_id = ? WHERE meta_key = ?",
+                (agent_name, "primary"),
+            )
+            conn.commit()
+            conn.close()
+            try:
+                import pwd
+                uid = pwd.getpwnam("openclaw").pw_uid
+                gid = pwd.getpwnam("openclaw").pw_gid
+                os.chown(dest, uid, gid)
+            except Exception:
+                pass
+            cloned += 1
+        except Exception as e:
+            log(f"Failed to clone SQLite auth to {agent_name}: {e}")
+
+    if cloned:
+        log(f"Cloned SQLite auth to {cloned} agent(s) from {best_src}")
+    return True
+
+
+def _sync_json_auth():
+    """Legacy: propagate auth-profiles.json via shared-auth symlinks (OpenClaw <6.6)."""
+    import glob as _glob
+    import shutil
+
     state_dir = os.environ.get("OPENCLAW_STATE_DIR", os.path.join(HOME, ".openclaw"))
     shared_dir = os.path.join(state_dir, "shared-auth")
     shared_path = os.path.join(shared_dir, "auth-profiles.json")
-
-    import glob as _glob
-    import shutil
 
     agent_dirs = _glob.glob(os.path.join(state_dir, "agents", "*", "agent"))
     agent_auth_files = [os.path.join(d, "auth-profiles.json") for d in agent_dirs]
@@ -1300,9 +1422,6 @@ def sync_to_shared_auth():
             existing = [gateway_auth]
 
     if not existing:
-        # Broad search: openclaw may write auth to a subdirectory we don't
-        # anticipate (e.g. gateway/agent/, a default profile dir, etc.).
-        # Walk the state dir to find any auth-profiles.json we missed.
         for root, _dirs, files in os.walk(state_dir):
             if "shared-auth" in root:
                 continue
@@ -1342,7 +1461,6 @@ def sync_to_shared_auth():
         log(f"Failed to sync shared-auth: {e}")
         return
 
-    # Also sync auth-state.json if present alongside the best source
     best_dir = os.path.dirname(best)
     state_src = os.path.join(best_dir, "auth-state.json")
     state_dst = os.path.join(shared_dir, "auth-state.json")
@@ -1364,7 +1482,6 @@ def sync_to_shared_auth():
             elif os.path.exists(target):
                 os.unlink(target)
             os.symlink(shared_path, target)
-            # Also link auth-state.json
             state_target = os.path.join(agent_dir, "auth-state.json")
             if os.path.exists(state_dst):
                 if os.path.islink(state_target) or os.path.exists(state_target):
@@ -1372,6 +1489,20 @@ def sync_to_shared_auth():
                 os.symlink(state_dst, state_target)
         except Exception as e:
             log(f"Failed to link auth to {agent_dir}: {e}")
+
+
+def sync_to_shared_auth():
+    """Propagate auth credentials to all agents.
+
+    Tries SQLite auth stores first (OpenClaw ≥6.6), falls back to the
+    legacy auth-profiles.json symlink approach for older versions.
+    """
+    try:
+        if _sync_sqlite_auth():
+            return
+    except Exception as e:
+        log(f"SQLite auth sync failed, falling back to JSON: {e}")
+    _sync_json_auth()
 
 
 def handle_set_agent_model(cmd_id, payload):

--- a/gateway/daemons/command_runner.py
+++ b/gateway/daemons/command_runner.py
@@ -89,6 +89,7 @@ def now_iso():
 RUNTIME_MODE = os.environ.get("RUNTIME_MODE", "systemd")
 COMPOSE_PROJECT = os.environ.get("COMPOSE_PROJECT", "yourhq")
 
+
 # This gateway's identity. Used to filter lease_command calls so multiple
 # gateways running against the same Supabase don't steal each other's work.
 # Prefer the process env, but fall back to gateway.env (which the entrypoint
@@ -100,7 +101,8 @@ def _resolve_gateway_id():
         return gid
     _gw_env = os.path.join(
         os.environ.get("OPENCLAW_STATE_DIR", os.path.join(HOME, ".openclaw")),
-        "secrets", "gateway.env",
+        "secrets",
+        "gateway.env",
     )
     if os.path.isfile(_gw_env):
         with open(_gw_env) as f:
@@ -111,6 +113,7 @@ def _resolve_gateway_id():
                     if val:
                         return val
     return gid or "default"
+
 
 GATEWAY_ID = _resolve_gateway_id()
 GATEWAY_LABEL = os.environ.get("GATEWAY_LABEL", GATEWAY_ID)
@@ -1343,9 +1346,7 @@ def _sync_sqlite_auth():
             continue
         try:
             conn = sqlite3.connect(db_path)
-            row = conn.execute(
-                "SELECT store_json FROM auth_profile_store LIMIT 1"
-            ).fetchone()
+            row = conn.execute("SELECT store_json FROM auth_profile_store LIMIT 1").fetchone()
             conn.close()
             if row and len(row[0]) > 10:
                 best_src = db_path
@@ -1368,12 +1369,8 @@ def _sync_sqlite_auth():
         if os.path.isfile(dest):
             try:
                 conn = sqlite3.connect(dest)
-                row = conn.execute(
-                    "SELECT store_json FROM auth_profile_store LIMIT 1"
-                ).fetchone()
-                aid = conn.execute(
-                    "SELECT agent_id FROM schema_meta WHERE meta_key = 'primary'"
-                ).fetchone()
+                row = conn.execute("SELECT store_json FROM auth_profile_store LIMIT 1").fetchone()
+                aid = conn.execute("SELECT agent_id FROM schema_meta WHERE meta_key = 'primary'").fetchone()
                 conn.close()
                 if row and len(row[0]) > 10 and aid and aid[0] == agent_name:
                     continue
@@ -1396,6 +1393,7 @@ def _sync_sqlite_auth():
             conn.close()
             try:
                 import pwd
+
                 uid = pwd.getpwnam("openclaw").pw_uid
                 gid = pwd.getpwnam("openclaw").pw_gid
                 os.chown(dest, uid, gid)

--- a/gateway/daemons/command_runner.py
+++ b/gateway/daemons/command_runner.py
@@ -346,6 +346,13 @@ def build_command(action, agent_slug, payload):
             return None, "Gateway updates in e2b mode are managed by the worker service"
         return ["bash", "-c", "cd ~ && git pull && ./install.sh --update"], "Updating gateway (git pull)"
 
+    elif action == "backup_gateway":
+        daemon_dir = os.environ.get("DAEMON_DIR", "/opt/yourhq/daemons")
+        backup_script = os.path.join(daemon_dir, "gateway_backup.py")
+        if not os.path.isfile(backup_script):
+            backup_script = os.path.join(os.path.dirname(os.path.abspath(__file__)), "gateway_backup.py")
+        return ["python3", backup_script, "backup"], "Backing up gateway state"
+
     else:
         return None, f"Unknown action: {action}"
 

--- a/gateway/daemons/gateway_backup.py
+++ b/gateway/daemons/gateway_backup.py
@@ -28,9 +28,7 @@ import time
 import urllib.error
 import urllib.request
 
-logging.basicConfig(
-    level=logging.INFO, format="[gateway_backup] %(message)s"
-)
+logging.basicConfig(level=logging.INFO, format="[gateway_backup] %(message)s")
 log = logging.getLogger("gateway_backup")
 
 SUPABASE_URL = os.environ.get("SUPABASE_URL", "")
@@ -56,7 +54,9 @@ def _storage_api(method: str, endpoint: str, body: dict | None = None, timeout: 
     url = f"{SUPABASE_URL.rstrip('/')}/storage/v1/{endpoint}"
     data = json.dumps(body).encode() if body is not None else None
     req = urllib.request.Request(
-        url, data=data, method=method,
+        url,
+        data=data,
+        method=method,
         headers={
             "apikey": SUPABASE_KEY,
             "Authorization": f"Bearer {SUPABASE_KEY}",
@@ -72,7 +72,9 @@ def _api_patch(table: str, match: dict, body: dict) -> None:
     url = f"{SUPABASE_URL.rstrip('/')}/rest/v1/{table}?{params}"
     data = json.dumps(body).encode()
     req = urllib.request.Request(
-        url, data=data, method="PATCH",
+        url,
+        data=data,
+        method="PATCH",
         headers={
             "apikey": SUPABASE_KEY,
             "Authorization": f"Bearer {SUPABASE_KEY}",
@@ -89,11 +91,15 @@ def _api_patch(table: str, match: dict, body: dict) -> None:
 def _list_backups() -> list[dict]:
     """List all backup files for this gateway, sorted newest-first."""
     try:
-        items = _storage_api("POST", f"object/list/{BUCKET}", {
-            "prefix": f"{GATEWAY_ID}/",
-            "limit": 100,
-            "sortBy": {"column": "name", "order": "desc"},
-        })
+        items = _storage_api(
+            "POST",
+            f"object/list/{BUCKET}",
+            {
+                "prefix": f"{GATEWAY_ID}/",
+                "limit": 100,
+                "sortBy": {"column": "name", "order": "desc"},
+            },
+        )
     except urllib.error.URLError as e:
         log.warning("Failed to list backups: %s", e)
         return []
@@ -181,7 +187,9 @@ def create_backup() -> dict:
 
     url = _storage_url(storage_path)
     req = urllib.request.Request(
-        url, data=data, method="PUT",
+        url,
+        data=data,
+        method="PUT",
         headers={
             "apikey": SUPABASE_KEY,
             "Authorization": f"Bearer {SUPABASE_KEY}",
@@ -232,7 +240,8 @@ def restore_backup() -> dict:
         file_path = f"{GATEWAY_ID}/{b['name']}"
         url = _storage_url(file_path)
         req = urllib.request.Request(
-            url, headers={
+            url,
+            headers={
                 "apikey": SUPABASE_KEY,
                 "Authorization": f"Bearer {SUPABASE_KEY}",
             },
@@ -265,6 +274,7 @@ def restore_backup() -> dict:
         # Fix ownership if running as root but openclaw user exists
         try:
             import pwd
+
             pw = pwd.getpwnam("openclaw")
             uid, gid = pw.pw_uid, pw.pw_gid
             for root, dirs, files in os.walk(OPENCLAW_HOME, followlinks=False):
@@ -291,9 +301,12 @@ def get_status() -> dict:
 
     backups = _list_backups()
 
-    url = f"{SUPABASE_URL.rstrip('/')}/rest/v1/gateways?slug=eq.{GATEWAY_ID}&select=last_backup_at,last_backup_size_bytes"
+    url = (
+        f"{SUPABASE_URL.rstrip('/')}/rest/v1/gateways?slug=eq.{GATEWAY_ID}&select=last_backup_at,last_backup_size_bytes"
+    )
     req = urllib.request.Request(
-        url, headers={
+        url,
+        headers={
             "apikey": SUPABASE_KEY,
             "Authorization": f"Bearer {SUPABASE_KEY}",
             "Accept": "application/json",

--- a/gateway/daemons/gateway_backup.py
+++ b/gateway/daemons/gateway_backup.py
@@ -1,0 +1,338 @@
+"""Gateway state backup and restore.
+
+Backs up ~/.openclaw/ (auth stores, config, secrets) to Supabase Storage
+and restores on boot if no local state exists. Used by:
+
+  - entrypoint.sh (restore on boot, backup on SIGTERM)
+  - command_runner.py (backup_gateway command action from UI)
+  - keepalive scripts (backup before extending sandbox timeout)
+
+Retention: keeps the 3 most recent backups per gateway, prunes anything
+older than 7 days. Restore picks the newest available backup; if it's
+corrupt, falls back to the next.
+
+Usage as CLI:
+  python3 gateway_backup.py backup
+  python3 gateway_backup.py restore
+  python3 gateway_backup.py status   # prints JSON with last backup info
+"""
+
+import io
+import json
+import logging
+import os
+import re
+import sys
+import tarfile
+import time
+import urllib.error
+import urllib.request
+
+logging.basicConfig(
+    level=logging.INFO, format="[gateway_backup] %(message)s"
+)
+log = logging.getLogger("gateway_backup")
+
+SUPABASE_URL = os.environ.get("SUPABASE_URL", "")
+SUPABASE_KEY = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "")
+GATEWAY_ID = os.environ.get("GATEWAY_ID", "default")
+OPENCLAW_HOME = os.environ.get("OPENCLAW_HOME", os.path.expanduser("~/.openclaw"))
+
+BUCKET = "gateway-backups"
+MAX_BACKUPS = 3
+MAX_AGE_DAYS = 7
+
+EXCLUDE_DIRS = {"npm", "node_modules", "browser", "repo.git", "plugins"}
+EXCLUDE_EXTENSIONS = {".log", ".pid", ".sock"}
+
+TIMESTAMP_RE = re.compile(r"state-(\d{8}T\d{6}Z)\.tar\.gz$")
+
+
+def _storage_url(path: str) -> str:
+    return f"{SUPABASE_URL.rstrip('/')}/storage/v1/object/{BUCKET}/{path}"
+
+
+def _storage_api(method: str, endpoint: str, body: dict | None = None, timeout: int = 30):
+    url = f"{SUPABASE_URL.rstrip('/')}/storage/v1/{endpoint}"
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        url, data=data, method=method,
+        headers={
+            "apikey": SUPABASE_KEY,
+            "Authorization": f"Bearer {SUPABASE_KEY}",
+            "Content-Type": "application/json",
+        },
+    )
+    resp = urllib.request.urlopen(req, timeout=timeout)
+    return json.loads(resp.read().decode())
+
+
+def _api_patch(table: str, match: dict, body: dict) -> None:
+    params = "&".join(f"{k}=eq.{v}" for k, v in match.items())
+    url = f"{SUPABASE_URL.rstrip('/')}/rest/v1/{table}?{params}"
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(
+        url, data=data, method="PATCH",
+        headers={
+            "apikey": SUPABASE_KEY,
+            "Authorization": f"Bearer {SUPABASE_KEY}",
+            "Content-Type": "application/json",
+            "Prefer": "return=minimal",
+        },
+    )
+    try:
+        urllib.request.urlopen(req, timeout=15)
+    except urllib.error.URLError as e:
+        log.warning("Failed to update gateway metadata: %s", e)
+
+
+def _list_backups() -> list[dict]:
+    """List all backup files for this gateway, sorted newest-first."""
+    try:
+        items = _storage_api("POST", f"object/list/{BUCKET}", {
+            "prefix": f"{GATEWAY_ID}/",
+            "limit": 100,
+            "sortBy": {"column": "name", "order": "desc"},
+        })
+    except urllib.error.URLError as e:
+        log.warning("Failed to list backups: %s", e)
+        return []
+
+    backups = []
+    for item in items:
+        name = item.get("name", "")
+        m = TIMESTAMP_RE.search(name)
+        if m:
+            backups.append({"name": name, "timestamp": m.group(1), "metadata": item})
+    backups.sort(key=lambda b: b["timestamp"], reverse=True)
+    return backups
+
+
+def _prune_old_backups() -> int:
+    """Delete backups beyond MAX_BACKUPS or older than MAX_AGE_DAYS."""
+    backups = _list_backups()
+    if len(backups) <= MAX_BACKUPS:
+        return 0
+
+    cutoff = time.strftime(
+        "%Y%m%dT%H%M%SZ",
+        time.gmtime(time.time() - MAX_AGE_DAYS * 86400),
+    )
+
+    to_delete = []
+    for i, b in enumerate(backups):
+        if i >= MAX_BACKUPS or b["timestamp"] < cutoff:
+            to_delete.append(f"{GATEWAY_ID}/{b['name']}")
+
+    if not to_delete:
+        return 0
+
+    try:
+        _storage_api("DELETE", f"object/{BUCKET}", {"prefixes": to_delete})
+        log.info("Pruned %d old backup(s)", len(to_delete))
+    except urllib.error.URLError as e:
+        log.warning("Failed to prune backups: %s", e)
+    return len(to_delete)
+
+
+def _tar_filter(tarinfo: tarfile.TarInfo) -> tarfile.TarInfo | None:
+    parts = tarinfo.name.split("/")
+    for part in parts:
+        if part in EXCLUDE_DIRS:
+            return None
+    if any(tarinfo.name.endswith(ext) for ext in EXCLUDE_EXTENSIONS):
+        return None
+    if tarinfo.size > 50 * 1024 * 1024:
+        return None
+    return tarinfo
+
+
+def create_backup() -> dict:
+    """Tar ~/.openclaw/ and upload to Supabase Storage.
+
+    Returns dict with keys: ok, size_bytes, path, error.
+    """
+    if not SUPABASE_URL or not SUPABASE_KEY:
+        return {"ok": False, "error": "Missing Supabase credentials"}
+
+    if not os.path.isdir(OPENCLAW_HOME):
+        return {"ok": False, "error": f"{OPENCLAW_HOME} does not exist"}
+
+    log.info("Creating backup of %s ...", OPENCLAW_HOME)
+    start = time.time()
+
+    timestamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    storage_path = f"{GATEWAY_ID}/state-{timestamp}.tar.gz"
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for entry in sorted(os.listdir(OPENCLAW_HOME)):
+            if entry in EXCLUDE_DIRS:
+                continue
+            full = os.path.join(OPENCLAW_HOME, entry)
+            try:
+                tar.add(full, arcname=entry, filter=_tar_filter)
+            except (PermissionError, OSError) as e:
+                log.warning("Skipping %s: %s", entry, e)
+
+    data = buf.getvalue()
+    size = len(data)
+    log.info("Tarball: %d bytes (%.1f KB), uploading to %s ...", size, size / 1024, storage_path)
+
+    url = _storage_url(storage_path)
+    req = urllib.request.Request(
+        url, data=data, method="PUT",
+        headers={
+            "apikey": SUPABASE_KEY,
+            "Authorization": f"Bearer {SUPABASE_KEY}",
+            "Content-Type": "application/gzip",
+            "x-upsert": "true",
+        },
+    )
+    try:
+        urllib.request.urlopen(req, timeout=120)
+    except urllib.error.URLError as e:
+        msg = str(e)
+        if hasattr(e, "read"):
+            msg = e.read().decode(errors="replace")
+        return {"ok": False, "error": f"Upload failed: {msg}"}
+
+    elapsed = time.time() - start
+    log.info("Backup uploaded in %.1fs (%d bytes)", elapsed, size)
+
+    _api_patch(
+        "gateways",
+        {"slug": GATEWAY_ID},
+        {
+            "last_backup_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "last_backup_size_bytes": size,
+        },
+    )
+
+    _prune_old_backups()
+
+    return {"ok": True, "size_bytes": size, "path": storage_path}
+
+
+def restore_backup() -> dict:
+    """Download the newest backup from Supabase Storage and extract to ~/.openclaw/.
+
+    Tries backups newest-first; skips corrupt archives and falls back to the next.
+    Returns dict with keys: ok, restored, path, error.
+    """
+    if not SUPABASE_URL or not SUPABASE_KEY:
+        return {"ok": False, "restored": False, "error": "Missing Supabase credentials"}
+
+    backups = _list_backups()
+    if not backups:
+        log.info("No backup found for gateway %s — starting fresh.", GATEWAY_ID)
+        return {"ok": True, "restored": False}
+
+    for b in backups:
+        file_path = f"{GATEWAY_ID}/{b['name']}"
+        url = _storage_url(file_path)
+        req = urllib.request.Request(
+            url, headers={
+                "apikey": SUPABASE_KEY,
+                "Authorization": f"Bearer {SUPABASE_KEY}",
+            },
+        )
+
+        try:
+            resp = urllib.request.urlopen(req, timeout=120)
+            data = resp.read()
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                log.warning("Backup %s not found, trying next ...", b["name"])
+                continue
+            log.warning("Download failed for %s: %s, trying next ...", b["name"], e)
+            continue
+        except urllib.error.URLError as e:
+            log.warning("Download failed for %s: %s, trying next ...", b["name"], e)
+            continue
+
+        log.info("Downloaded %s: %d bytes. Extracting ...", b["name"], len(data))
+
+        os.makedirs(OPENCLAW_HOME, exist_ok=True)
+        buf = io.BytesIO(data)
+        try:
+            with tarfile.open(fileobj=buf, mode="r:gz") as tar:
+                tar.extractall(path=OPENCLAW_HOME)
+        except (tarfile.TarError, EOFError, OSError) as e:
+            log.warning("Corrupt backup %s: %s — trying next ...", b["name"], e)
+            continue
+
+        # Fix ownership if running as root but openclaw user exists
+        try:
+            import pwd
+            pw = pwd.getpwnam("openclaw")
+            uid, gid = pw.pw_uid, pw.pw_gid
+            for root, dirs, files in os.walk(OPENCLAW_HOME, followlinks=False):
+                for name in dirs + files:
+                    try:
+                        os.lchown(os.path.join(root, name), uid, gid)
+                    except (FileNotFoundError, OSError):
+                        pass
+            log.info("Fixed ownership to openclaw:%d", uid)
+        except (KeyError, PermissionError):
+            pass
+
+        log.info("Restore complete from %s.", b["name"])
+        return {"ok": True, "restored": True, "path": file_path}
+
+    log.warning("All %d backups failed to restore.", len(backups))
+    return {"ok": False, "restored": False, "error": "All backups corrupt or unavailable"}
+
+
+def get_status() -> dict:
+    """Return backup metadata: count, newest, total size."""
+    if not SUPABASE_URL or not SUPABASE_KEY:
+        return {"ok": False, "error": "Missing Supabase credentials"}
+
+    backups = _list_backups()
+
+    url = f"{SUPABASE_URL.rstrip('/')}/rest/v1/gateways?slug=eq.{GATEWAY_ID}&select=last_backup_at,last_backup_size_bytes"
+    req = urllib.request.Request(
+        url, headers={
+            "apikey": SUPABASE_KEY,
+            "Authorization": f"Bearer {SUPABASE_KEY}",
+            "Accept": "application/json",
+        },
+    )
+    gw_meta = {}
+    try:
+        resp = urllib.request.urlopen(req, timeout=15)
+        rows = json.loads(resp.read().decode())
+        if rows:
+            gw_meta = rows[0]
+    except urllib.error.URLError:
+        pass
+
+    return {
+        "ok": True,
+        "has_backup": len(backups) > 0,
+        "backup_count": len(backups),
+        "backups": [{"name": b["name"], "timestamp": b["timestamp"]} for b in backups],
+        "last_backup_at": gw_meta.get("last_backup_at"),
+        "last_backup_size_bytes": gw_meta.get("last_backup_size_bytes"),
+    }
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: gateway_backup.py [backup|restore|status]", file=sys.stderr)
+        sys.exit(1)
+
+    cmd = sys.argv[1]
+    if cmd == "backup":
+        result = create_backup()
+    elif cmd == "restore":
+        result = restore_backup()
+    elif cmd == "status":
+        result = get_status()
+    else:
+        print(f"Unknown command: {cmd}", file=sys.stderr)
+        sys.exit(1)
+
+    print(json.dumps(result))
+    sys.exit(0 if result.get("ok") else 1)

--- a/gateway/daemons/inbox_dispatcher.py
+++ b/gateway/daemons/inbox_dispatcher.py
@@ -58,7 +58,25 @@ RECONCILE_INTERVAL = int(os.environ.get("RECONCILE_INTERVAL", "120"))
 WAKE_COOLDOWN = int(os.environ.get("WAKE_COOLDOWN", "30"))
 
 # This gateway's slug — only wake agents bound to this gateway.
-GATEWAY_ID = os.environ.get("GATEWAY_ID", "default")
+# Prefer process env, fall back to gateway.env so daemons restarted
+# outside the entrypoint still get the right ID.
+def _resolve_gateway_id():
+    gid = os.environ.get("GATEWAY_ID")
+    if gid and gid != "default":
+        return gid
+    _state = os.environ.get("OPENCLAW_HOME", os.path.expanduser("~/.openclaw"))
+    _gw_env = os.path.join(_state, "secrets", "gateway.env")
+    if os.path.isfile(_gw_env):
+        with open(_gw_env) as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith("GATEWAY_ID="):
+                    val = line.split("=", 1)[1].strip("'\"")
+                    if val:
+                        return val
+    return gid or "default"
+
+GATEWAY_ID = _resolve_gateway_id()
 
 DEFAULT_TENANT_ID = "00000000-0000-0000-0000-000000000000"
 TENANT_ID = os.environ.get("TENANT_ID", DEFAULT_TENANT_ID)

--- a/gateway/daemons/inbox_dispatcher.py
+++ b/gateway/daemons/inbox_dispatcher.py
@@ -57,6 +57,7 @@ SUPABASE_KEY = ""
 RECONCILE_INTERVAL = int(os.environ.get("RECONCILE_INTERVAL", "120"))
 WAKE_COOLDOWN = int(os.environ.get("WAKE_COOLDOWN", "30"))
 
+
 # This gateway's slug — only wake agents bound to this gateway.
 # Prefer process env, fall back to gateway.env so daemons restarted
 # outside the entrypoint still get the right ID.
@@ -75,6 +76,7 @@ def _resolve_gateway_id():
                     if val:
                         return val
     return gid or "default"
+
 
 GATEWAY_ID = _resolve_gateway_id()
 

--- a/gateway/entrypoint.sh
+++ b/gateway/entrypoint.sh
@@ -187,6 +187,7 @@ if [ -n "${SUPABASE_URL:-}" ] && [ -n "${SUPABASE_SERVICE_ROLE_KEY:-}" ]; then
   mkdir -p "$_secrets_dir"
   chmod 700 "$_secrets_dir"
   cat > "$_secrets_dir/gateway.env" <<GWEOF
+GATEWAY_ID=${GATEWAY_ID}
 SUPABASE_URL=${SUPABASE_URL}
 SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY}
 EMBEDDER_URL=${EMBEDDER_URL:-http://embedder:18801}
@@ -738,6 +739,14 @@ fi
 log "Clearing stale Chrome Singleton* locks in all agent profiles ..."
 find "$HOME/.openclaw/browser" -maxdepth 3 -name "Singleton*" -delete 2>/dev/null || true
 
+# OpenClaw >=6.6 blocks plugins whose path is world-writable (mode & 002).
+# E2B sandboxes create npm project dirs with 777 perms, which triggers this
+# check for the codex plugin. Tighten all dirs/files under the npm tree.
+if [ -d "$HOME/.openclaw/npm" ]; then
+  find "$HOME/.openclaw/npm" -type d -perm /o+w -exec chmod 755 {} + 2>/dev/null || true
+  find "$HOME/.openclaw/npm" -type f -perm /o+w -exec chmod 644 {} + 2>/dev/null || true
+fi
+
 # ─────────────────────────────────────────────────────────────
 # 12. In hosted mode, start daemons in-process.
 #     In docker mode they run as separate containers (dispatcher,
@@ -748,6 +757,15 @@ find "$HOME/.openclaw/browser" -maxdepth 3 -name "Singleton*" -delete 2>/dev/nul
 if [ "$RUNTIME_MODE" = "hosted" ]; then
   DAEMON_DIR="/opt/yourhq/daemons"
   [ -d "$DAEMON_DIR" ] || DAEMON_DIR="$(dirname "$(readlink -f "$0")")/daemons"
+
+  # Kill stale daemons left over from a previous crashed run. In hosted mode
+  # there is no container boundary — orphaned processes survive gateway crashes
+  # and pile up on each restart.
+  log "Killing stale daemons from previous run (if any) ..."
+  for _daemon in embedder.py inbox_dispatcher.py command_runner.py file_processor.py source_sync.py plugin_runner.py; do
+    pkill -f "python3.*${_daemon}" 2>/dev/null || true
+  done
+  sleep 1
 
   if [ -f "$DAEMON_DIR/embedder.py" ] && [ -z "${EMBEDDER_URL:-}" ]; then
     # Use port 9100 in hosted mode — 18801 is the first CDP port allocated

--- a/gateway/entrypoint.sh
+++ b/gateway/entrypoint.sh
@@ -39,8 +39,18 @@ if [ -f /opt/yourhq/hooks/init.sh ]; then
   source /opt/yourhq/hooks/init.sh
 fi
 
-# Forward SIGTERM from tini to children
-trap 'kill -TERM $(jobs -p) 2>/dev/null || true; exit 0' TERM INT
+# On SIGTERM: backup state to Supabase Storage, then forward signal to children.
+_shutdown() {
+  log "SIGTERM received — backing up gateway state before exit ..."
+  BACKUP_SCRIPT="${DAEMON_DIR:-/opt/yourhq/daemons}/gateway_backup.py"
+  [ -f "$BACKUP_SCRIPT" ] || BACKUP_SCRIPT="$(dirname "$(readlink -f "$0")")/daemons/gateway_backup.py"
+  if [ -f "$BACKUP_SCRIPT" ] && [ -n "${SUPABASE_URL:-}" ] && [ -n "${SUPABASE_SERVICE_ROLE_KEY:-}" ]; then
+    timeout 60 python3 "$BACKUP_SCRIPT" backup 2>&1 | while read -r line; do log "$line"; done || true
+  fi
+  kill -TERM $(jobs -p) 2>/dev/null || true
+  exit 0
+}
+trap '_shutdown' TERM INT
 
 OPENCLAW_HOME="${OPENCLAW_HOME:-$HOME/.openclaw}"
 CONFIG="$OPENCLAW_HOME/openclaw.json"
@@ -194,6 +204,29 @@ EMBEDDER_URL=${EMBEDDER_URL:-http://embedder:18801}
 EMBEDDER_MODEL=${EMBEDDER_MODEL:-BAAI/bge-small-en-v1.5}
 GWEOF
   chmod 600 "$_secrets_dir/gateway.env"
+fi
+
+# ─────────────────────────────────────────────────────────────
+# 0b. Restore from backup (if no local agent state exists).
+#     If the gateway is starting fresh (no agents dir = first boot
+#     or recreated sandbox), check Supabase Storage for a previous
+#     backup and extract it. This restores auth tokens, configs,
+#     and secrets so the gateway comes back online without reauth.
+# ─────────────────────────────────────────────────────────────
+
+if [ ! -d "$OPENCLAW_HOME/agents" ] && [ -n "${SUPABASE_URL:-}" ] && [ -n "${SUPABASE_SERVICE_ROLE_KEY:-}" ]; then
+  BACKUP_SCRIPT="${DAEMON_DIR:-/opt/yourhq/daemons}/gateway_backup.py"
+  [ -f "$BACKUP_SCRIPT" ] || BACKUP_SCRIPT="$(dirname "$(readlink -f "$0")")/daemons/gateway_backup.py"
+  if [ -f "$BACKUP_SCRIPT" ]; then
+    log "No local agent state — checking for backup to restore ..."
+    if python3 "$BACKUP_SCRIPT" restore 2>&1 | while read -r line; do log "$line"; done; then
+      log "Backup restore complete."
+    else
+      log "No backup found or restore failed — continuing with fresh setup."
+    fi
+  fi
+elif [ -d "$OPENCLAW_HOME/agents" ]; then
+  log "Local agent state exists — skipping restore."
 fi
 
 # ─────────────────────────────────────────────────────────────
@@ -745,6 +778,7 @@ find "$HOME/.openclaw/browser" -maxdepth 3 -name "Singleton*" -delete 2>/dev/nul
 if [ -d "$HOME/.openclaw/npm" ]; then
   find "$HOME/.openclaw/npm" -type d -perm /o+w -exec chmod 755 {} + 2>/dev/null || true
   find "$HOME/.openclaw/npm" -type f -perm /o+w -exec chmod 644 {} + 2>/dev/null || true
+  find "$HOME/.openclaw/npm" -path "*/bin/*" -type f -exec chmod 755 {} + 2>/dev/null || true
 fi
 
 # ─────────────────────────────────────────────────────────────

--- a/gateway/entrypoint.sh
+++ b/gateway/entrypoint.sh
@@ -47,6 +47,7 @@ _shutdown() {
   if [ -f "$BACKUP_SCRIPT" ] && [ -n "${SUPABASE_URL:-}" ] && [ -n "${SUPABASE_SERVICE_ROLE_KEY:-}" ]; then
     timeout 60 python3 "$BACKUP_SCRIPT" backup 2>&1 | while read -r line; do log "$line"; done || true
   fi
+  # shellcheck disable=SC2046
   kill -TERM $(jobs -p) 2>/dev/null || true
   exit 0
 }

--- a/gateway/scripts/add-agent.sh
+++ b/gateway/scripts/add-agent.sh
@@ -245,11 +245,11 @@ if [ -n "$AGENT_MODEL_ARG" ]; then
   AGENT_MODEL="$AGENT_MODEL_ARG"
 fi
 if [ -z "$AGENT_MODEL" ]; then
-  AGENT_MODEL=$(jq -r '.model // empty' "$AGENT_JSON")
+  AGENT_MODEL=$(jq -r '.model // empty' "$AGENT_JSON" 2>/dev/null || true)
 fi
 if [ -z "$AGENT_MODEL" ]; then
   # openclaw 5.x stores the default model at .agents.defaults.model.primary.
-  AGENT_MODEL=$(jq -r '.agents.defaults.model.primary // empty' "$CONFIG" 2>/dev/null)
+  AGENT_MODEL=$(jq -r '.agents.defaults.model.primary // empty' "$CONFIG" 2>/dev/null || true)
 fi
 if [ -z "$AGENT_MODEL" ]; then
   # `models status --json` returns an object with resolvedDefault/defaultModel.

--- a/gateway/tests/test_command_runner.py
+++ b/gateway/tests/test_command_runner.py
@@ -553,6 +553,140 @@ def test_sync_to_shared_auth_skips_when_nothing_found(monkeypatch, tmp_path):
     assert not shared.exists()
 
 
+def _make_sqlite_auth(path, agent_id, auth_data='{"version":1,"profiles":{"openai:test":{"type":"oauth"}}}'):
+    """Helper: create a valid openclaw-agent.sqlite with auth data."""
+    import sqlite3
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        "CREATE TABLE schema_meta "
+        "(meta_key TEXT, type TEXT, version TEXT, agent_id TEXT, "
+        "extra TEXT, created_at INTEGER, updated_at INTEGER)"
+    )
+    conn.execute(
+        "INSERT INTO schema_meta VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("primary", "agent", "1", agent_id, None, 0, 0),
+    )
+    conn.execute("CREATE TABLE auth_profile_store (key TEXT, store_json TEXT, updated_at INTEGER)")
+    if auth_data:
+        conn.execute("INSERT INTO auth_profile_store VALUES (?, ?, ?)", ("primary", auth_data, 0))
+    conn.execute("CREATE TABLE cache_entries (key TEXT, value TEXT)")
+    conn.execute("CREATE TABLE auth_profile_state (key TEXT, state_json TEXT, updated_at INTEGER)")
+    conn.commit()
+    conn.close()
+
+
+def test_sqlite_auth_clone_to_new_agent(monkeypatch, tmp_path):
+    """New agents without SQLite auth get cloned from the source agent."""
+    import command_runner as cr
+
+    state_dir = tmp_path / ".openclaw"
+    monkeypatch.setenv("OPENCLAW_STATE_DIR", str(state_dir))
+    monkeypatch.setattr(cr, "HOME", str(tmp_path))
+
+    # Source agent with valid auth
+    src = state_dir / "agents" / "agent-a" / "agent"
+    _make_sqlite_auth(src / "openclaw-agent.sqlite", "agent-a")
+
+    # Target agent with no SQLite
+    tgt = state_dir / "agents" / "agent-b" / "agent"
+    tgt.mkdir(parents=True)
+
+    cr.sync_to_shared_auth()
+
+    import sqlite3
+
+    db = sqlite3.connect(str(tgt / "openclaw-agent.sqlite"))
+    aid = db.execute("SELECT agent_id FROM schema_meta WHERE meta_key = 'primary'").fetchone()
+    store = db.execute("SELECT store_json FROM auth_profile_store LIMIT 1").fetchone()
+    db.close()
+
+    assert aid[0] == "agent-b"
+    assert store is not None and len(store[0]) > 10
+
+
+def test_sqlite_auth_clone_patches_agent_id(monkeypatch, tmp_path):
+    """Cloned SQLite must have agent_id patched to match the target directory."""
+    import sqlite3
+
+    import command_runner as cr
+
+    state_dir = tmp_path / ".openclaw"
+    monkeypatch.setenv("OPENCLAW_STATE_DIR", str(state_dir))
+    monkeypatch.setattr(cr, "HOME", str(tmp_path))
+
+    src = state_dir / "agents" / "source" / "agent"
+    _make_sqlite_auth(src / "openclaw-agent.sqlite", "source")
+
+    for name in ["target-1", "target-2"]:
+        (state_dir / "agents" / name / "agent").mkdir(parents=True)
+
+    cr.sync_to_shared_auth()
+
+    for name in ["target-1", "target-2"]:
+        db = sqlite3.connect(str(state_dir / "agents" / name / "agent" / "openclaw-agent.sqlite"))
+        aid = db.execute("SELECT agent_id FROM schema_meta WHERE meta_key = 'primary'").fetchone()
+        db.close()
+        assert aid[0] == name
+
+
+def test_sqlite_auth_skips_agent_with_valid_auth(monkeypatch, tmp_path):
+    """Agents that already have valid auth and correct agent_id are not overwritten."""
+    import sqlite3
+
+    import command_runner as cr
+
+    state_dir = tmp_path / ".openclaw"
+    monkeypatch.setenv("OPENCLAW_STATE_DIR", str(state_dir))
+    monkeypatch.setattr(cr, "HOME", str(tmp_path))
+
+    src = state_dir / "agents" / "agent-a" / "agent"
+    _make_sqlite_auth(src / "openclaw-agent.sqlite", "agent-a")
+
+    tgt = state_dir / "agents" / "agent-b" / "agent"
+    own_auth = '{"version":1,"profiles":{"anthropic:own":{"type":"api-key"}}}'
+    _make_sqlite_auth(tgt / "openclaw-agent.sqlite", "agent-b", auth_data=own_auth)
+
+    cr.sync_to_shared_auth()
+
+    db = sqlite3.connect(str(tgt / "openclaw-agent.sqlite"))
+    store = db.execute("SELECT store_json FROM auth_profile_store LIMIT 1").fetchone()
+    db.close()
+    assert "anthropic:own" in store[0]
+
+
+def test_sqlite_auth_fixes_mismatched_agent_id(monkeypatch, tmp_path):
+    """An existing SQLite with wrong agent_id gets re-cloned with the correct ID."""
+    import sqlite3
+    import time
+
+    import command_runner as cr
+
+    state_dir = tmp_path / ".openclaw"
+    monkeypatch.setenv("OPENCLAW_STATE_DIR", str(state_dir))
+    monkeypatch.setattr(cr, "HOME", str(tmp_path))
+
+    # Source agent — created first so it's the only valid candidate.
+    src = state_dir / "agents" / "agent-a" / "agent"
+    _make_sqlite_auth(src / "openclaw-agent.sqlite", "agent-a")
+    # Ensure src has a newer mtime than the target.
+    import os
+    future = time.time() + 1
+    os.utime(str(src / "openclaw-agent.sqlite"), (future, future))
+
+    # Target: has auth but wrong agent_id (simulates a raw copy without patching).
+    tgt = state_dir / "agents" / "agent-b" / "agent"
+    _make_sqlite_auth(tgt / "openclaw-agent.sqlite", "agent-a")
+
+    cr.sync_to_shared_auth()
+
+    db = sqlite3.connect(str(tgt / "openclaw-agent.sqlite"))
+    aid = db.execute("SELECT agent_id FROM schema_meta WHERE meta_key = 'primary'").fetchone()
+    db.close()
+    assert aid[0] == "agent-b"
+
+
 def test_auth_set_default_uses_models_set(monkeypatch):
     """openclaw 5.x: default model is set via `models set <target>` (the
     legacy `set-default` subcommand was removed)."""

--- a/gateway/tests/test_command_runner.py
+++ b/gateway/tests/test_command_runner.py
@@ -672,6 +672,7 @@ def test_sqlite_auth_fixes_mismatched_agent_id(monkeypatch, tmp_path):
     _make_sqlite_auth(src / "openclaw-agent.sqlite", "agent-a")
     # Ensure src has a newer mtime than the target.
     import os
+
     future = time.time() + 1
     os.utime(str(src / "openclaw-agent.sqlite"), (future, future))
 


### PR DESCRIPTION
## Summary

- **OpenClaw 6.6 upgrade**: Dockerfile pins 6.6, entrypoint handles breaking changes (world-writable plugin block, auth propagation)
- **Gateway backup/restore**: Automatic backup on SIGTERM, restore on fresh boot from Supabase Storage. Retention: 3 backups per gateway, 7-day max age. New Settings → Backups UI page.
- **Critical fix — add-agent.sh**: `|| true` on jq model lookups prevents exit code 5 when config lacks `agents.defaults.model.primary`, which blocked all new agent provisioning
- **Critical fix — bin permissions**: `find ... -path "*/bin/*" -exec chmod 755` preserves execute permissions on native binaries (codex) after the world-writable chmod fix
- **Workspace switch fix**: Navigate to section root instead of `window.location.reload()` — prevents 404 loops when switching to a workspace that doesn't have the same agent/resource

## Changed files

| Area | Files | What |
|---|---|---|
| Gateway | `entrypoint.sh` | Shutdown backup trap, Phase 0b restore, bin permission fix |
| Gateway | `gateway_backup.py` (new) | Backup/restore daemon with retention + fallback |
| Gateway | `command_runner.py` | `backup_gateway` command action |
| Gateway | `add-agent.sh` | `|| true` on jq model lookups |
| Gateway | `Dockerfile`, `Dockerfile.e2b` | Pin OpenClaw 6.6 |
| UI | `backups/` (new) | Settings → Backups page + server actions |
| UI | `workspace-switcher.tsx` | Section-root redirect on switch |
| UI | `types.ts` | `backup_gateway` action + gateway backup metadata |
| DB | `038_gateway_backups.sql` | Storage bucket + `last_backup_at` columns |

## Test plan

- [x] Backup taken on all 4 production sandboxes (Job Search, YourHQ, HQ Sales, Flight Recap)
- [x] Full restore test: spawned clean sandbox → restored YourHQ backup → verified all agents, auth, config, shared-auth, secrets match originals exactly
- [x] Gateway boots successfully on restored state with all 9 plugins and 5 daemons
- [x] Telegram pairing files confirmed present in backup tarballs
- [x] Dangling symlink fix verified (codex temp dirs no longer crash restore)
- [x] \`npx tsc --noEmit\` passes
- [ ] CI checks (ui, worker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)